### PR TITLE
UIレイアウトとページタイトルの改善

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -37,9 +37,11 @@ useSeoMeta({
   <UApp>
     <NuxtRouteAnnouncer />
     <NuxtLoadingIndicator />
-    <main class="pt-6 px-6">
-      <NuxtPage />
-    </main>
-    <FooterComponent />
+    <UContainer>
+      <main class="pt-6 px-6">
+        <NuxtPage />
+      </main>
+      <FooterComponent />
+    </UContainer>
   </UApp>
 </template>

--- a/app/pages/[year]/index.test.ts
+++ b/app/pages/[year]/index.test.ts
@@ -103,7 +103,8 @@ describe('[year]/index.vue', () => {
 
     // Check if component is rendered
     const html = wrapper.html();
-    expect(html).toContain('2024');
+    expect(html).toContain('Vue Fes Japan 2024');
+    expect(html).toContain('公式サイト');
     expect(html).toContain('TOPページに戻る');
 
     // Check SpeakerTable component
@@ -128,7 +129,8 @@ describe('[year]/index.vue', () => {
 
     // Check rendered content
     const html = wrapper.html();
-    expect(html).toContain('2024');
+    expect(html).toContain('Vue Fes Japan 2024');
+    expect(html).toContain('公式サイト');
     expect(html).toContain('TOPページに戻る');
 
     // Check that SpeakerTable exists but shows 0 speakers

--- a/app/pages/[year]/index.vue
+++ b/app/pages/[year]/index.vue
@@ -21,9 +21,21 @@ useSeoMeta({
 
 <template>
   <div>
-    <h1 class="font-semibold text-3xl text-gray-900 dark:text-white leading-tight">
-      Vue Fes Japan {{ $route.params.year }}
-    </h1>
+    <hgroup>
+      <h1 class="font-semibold text-3xl text-gray-900 dark:text-white leading-tight">
+        Vue Fes Japan {{ $route.params.year }}
+      </h1>
+      <p class="pt-6">
+        <a
+          :href="`https://vuefes.jp/${$route.params.year}/`"
+          target="_blank"
+          class="text-gray-500 dark:text-gray-400 text-xl underline hover:no-underline"
+        >
+          Vue Fes Japan {{ $route.params.year }}公式サイト
+          <UIcon name="i-heroicons-solid-arrow-top-right-on-square" class="ms-1 align-[-0.15rem]" />
+        </a>
+      </p>
+    </hgroup>
     <div class="pt-6">
       <nuxt-link to="/" class="text-gray-500 dark:text-gray-400 text-xl underline hover:no-underline">
         TOPページに戻る

--- a/app/pages/speakers/[name]/index.test.ts
+++ b/app/pages/speakers/[name]/index.test.ts
@@ -94,7 +94,7 @@ describe('speakers/[name]/index.vue', () => {
 
     // Check if component is rendered
     const html = wrapper.html();
-    expect(html).toContain('John Doe');
+    expect(html).toContain('John Doe 発表一覧');
     expect(html).toContain('TOPページに戻る');
 
     // Check SpeakerTable component
@@ -118,7 +118,7 @@ describe('speakers/[name]/index.vue', () => {
 
     // Check rendered content
     const html = wrapper.html();
-    expect(html).toContain('John Doe');
+    expect(html).toContain('John Doe 発表一覧');
     expect(html).toContain('Page not found');
     expect(html).toContain('TOP');
 
@@ -220,7 +220,7 @@ describe('speakers/[name]/index.vue', () => {
 
       // useHeadに渡された引数を確認
       expect(useHeadMock).toHaveBeenCalledWith({
-        title: 'John Doe',
+        title: 'John Doe 発表一覧',
       });
     });
   });
@@ -251,10 +251,10 @@ describe('speakers/[name]/index.vue', () => {
       });
 
       const html = wrapper.html();
-      expect(html).toContain('山田太郎');
+      expect(html).toContain('山田太郎 発表一覧');
       expect(useFetchSpeaker).toHaveBeenCalled();
       expect(useHeadMock).toHaveBeenCalledWith({
-        title: '山田太郎',
+        title: '山田太郎 発表一覧',
       });
     });
 

--- a/app/pages/speakers/[name]/index.vue
+++ b/app/pages/speakers/[name]/index.vue
@@ -6,7 +6,7 @@ const route = useRoute();
 const { filterNameSpeaker } = await useFetchSpeaker(route.params.name as string);
 
 useHead({
-  title: route.params.name as string,
+  title: `${route.params.name as string} 発表一覧`,
 });
 
 useSeoMeta({
@@ -22,7 +22,7 @@ useSeoMeta({
 <template>
   <div>
     <h1 class="font-semibold text-3xl text-gray-900 dark:text-white leading-tight">
-      {{ $route.params.name }}
+      {{ $route.params.name }} 発表一覧
     </h1>
     <template v-if="filterNameSpeaker && filterNameSpeaker.length > 0">
       <div class="pt-6">


### PR DESCRIPTION
- app.vueにUContainerコンポーネントを追加し、レイアウトを改善
- [year]ページにVue Fes Japan公式サイトへの外部リンクを追加
- speakers/[name]ページのタイトルに「発表一覧」を追加し、より明確に
- 関連するテストファイルを更新し、新しいタイトル形式に対応

🤖 Generated with [Claude Code](https://claude.ai/code)