### PR TITLE
fix: 型定義エラーを修正

### DIFF
--- a/app/composables/speaker.test.ts
+++ b/app/composables/speaker.test.ts
@@ -394,13 +394,13 @@ describe('speaker composables', () => {
 
       const result = await useFetchAllSpeakers();
 
-      expect(mockFetch).toHaveBeenCalledTimes(5);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
       years.forEach((year) => {
         expect(mockFetch).toHaveBeenCalledWith(`/api/speakers/${year}`);
       });
 
-      expect(result).toHaveLength(5);
-      expect(callOrder).toHaveLength(5);
+      expect(result).toHaveLength(3);
+      expect(callOrder).toHaveLength(3);
       expect(callOrder.sort()).toEqual(years.sort());
     });
 

--- a/app/composables/speaker.test.ts
+++ b/app/composables/speaker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { computed } from 'vue';
-import type { SpeakerInfo } from '~~/types';
+import type { SpeakerInfo, AcceptedYear } from '~~/types';
 
 // Import the mocked functions
 import { isValidYear, getAvailableYears } from '~/utils/years';
@@ -21,12 +21,16 @@ vi.stubGlobal('computed', computed);
 
 // We'll need to test the functions differently due to module resolution
 const useFetchSpeaker = async (params?: string) => {
-  const handler = params && isValidYear(params)
+  if (!params) {
+    const filterNameSpeaker = computed(() => []);
+    return { filterYearSpeaker: undefined, filterNameSpeaker };
+  }
+  const handler = isValidYear(params)
     ? async (year: string) => {
       const { data } = await (globalThis as unknown as { useFetch: typeof useFetch }).useFetch<SpeakerInfo[]>(`/api/speakers/${year}`);
       return { filterYearSpeaker: data, filterNameSpeaker: undefined };
     }
-    : async (name?: string) => {
+    : async (name: string) => {
       const years = getAvailableYears();
       const promises = years.map(year =>
         (globalThis as unknown as { $fetch: typeof $fetch }).$fetch<SpeakerInfo[]>(`/api/speakers/${year}`).then(speakers =>
@@ -339,7 +343,7 @@ describe('speaker composables', () => {
       const result = await useFetchSpeaker('bob');
 
       expect(result.filterNameSpeaker?.value).toHaveLength(1);
-      expect(result.filterNameSpeaker?.value?.[0].name).toEqual([
+      expect(result.filterNameSpeaker?.value?.[0]?.name).toEqual([
         'Alice Johnson',
         'Bob Smith',
         'Charlie Brown',
@@ -361,18 +365,16 @@ describe('speaker composables', () => {
       const result = await useFetchSpeaker('Speaker');
 
       expect(result.filterNameSpeaker?.value).toHaveLength(1);
-      expect(result.filterNameSpeaker?.value?.[0].title).toBeUndefined();
+      expect(result.filterNameSpeaker?.value?.[0]?.title).toBeUndefined();
     });
   });
 
   describe('同時APIコール', () => {
     it('fetchAllSpeakersWithYearsで同時リクエストを適切に処理する', async () => {
-      const years = ['2020', '2021', '2022', '2023', '2024'];
+      const years: AcceptedYear[] = ['2022', '2023', '2024'];
       vi.mocked(getAvailableYears).mockReturnValue(years);
 
-      const mockResponses = {
-        2020: [{ name: ['Speaker 2020'], title: 'Talk 2020', url: 'https://2020.com' }],
-        2021: [{ name: ['Speaker 2021'], title: 'Talk 2021', url: 'https://2021.com' }],
+      const mockResponses: Record<string, SpeakerInfo[]> = {
         2022: [{ name: ['Speaker 2022'], title: 'Talk 2022', url: 'https://2022.com' }],
         2023: [{ name: ['Speaker 2023'], title: 'Talk 2023', url: 'https://2023.com' }],
         2024: [{ name: ['Speaker 2024'], title: 'Talk 2024', url: 'https://2024.com' }],
@@ -381,6 +383,7 @@ describe('speaker composables', () => {
       const callOrder: string[] = [];
       mockFetch.mockImplementation((url: string) => {
         const year = url.split('/').pop();
+        if (!year) return Promise.resolve([]);
         callOrder.push(year);
         return new Promise((resolve) => {
           setTimeout(() => {
@@ -404,9 +407,10 @@ describe('speaker composables', () => {
     it('同時コールで正しい年の割り当てを維持する', async () => {
       vi.mocked(getAvailableYears).mockReturnValue(['2023', '2024']);
 
-      const delays = { 2023: 100, 2024: 50 };
+      const delays: Record<string, number> = { 2023: 100, 2024: 50 };
       mockFetch.mockImplementation((url: string) => {
         const year = url.split('/').pop();
+        if (!year) return Promise.resolve([]);
         return new Promise((resolve) => {
           setTimeout(() => {
             resolve([
@@ -490,8 +494,9 @@ describe('speaker composables', () => {
 
       const result = await useFetchAllSpeakers();
 
+      expect(result.length).toBeGreaterThan(0);
       expect(result[0]).toHaveProperty('year');
-      expect(typeof result[0].year).toBe('string');
+      expect(typeof result[0]?.year).toBe('string');
     });
   });
 });

--- a/app/composables/speaker.ts
+++ b/app/composables/speaker.ts
@@ -38,7 +38,10 @@ const fetchNameSpeakers = async (name?: string) => {
 };
 
 export const useFetchSpeaker = async (params?: string) => {
-  const handler = params && isValidYear(params)
+  if (!params) {
+    return fetchNameSpeakers('');
+  }
+  const handler = isValidYear(params)
     ? fetchYearSpeakers
     : fetchNameSpeakers;
   return handler(params);

--- a/app/pages/[year]/index.test.ts
+++ b/app/pages/[year]/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
+import type { SpeakerInfo } from '~~/types';
 import YearPage from './index.vue';
 
 // Import mocked functions
@@ -174,7 +175,7 @@ describe('[year]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       // useSeoMetaに渡された引数を取得
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
       expect(seoMetaArg).toHaveProperty('robots');
 
       // robots関数を実行して値を確認
@@ -200,7 +201,7 @@ describe('[year]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       // useSeoMetaに渡された引数を取得
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
       expect(seoMetaArg).toHaveProperty('robots');
 
       // robots関数を実行して値を確認
@@ -212,7 +213,7 @@ describe('[year]/index.vue', () => {
 
     it('filterYearSpeakerがnullの場合、robotsをnoindexに設定する', async () => {
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
-        filterYearSpeaker: ref(null),
+        filterYearSpeaker: ref<SpeakerInfo[] | undefined>(undefined),
         filterNameSpeaker: undefined,
       }));
 
@@ -226,7 +227,7 @@ describe('[year]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       expect(useSeoMetaMock).toHaveBeenCalled();
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
       const robotsValue = typeof seoMetaArg.robots === 'function'
         ? seoMetaArg.robots()
         : seoMetaArg.robots;
@@ -249,7 +250,7 @@ describe('[year]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       expect(useSeoMetaMock).toHaveBeenCalled();
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
       const robotsValue = typeof seoMetaArg.robots === 'function'
         ? seoMetaArg.robots()
         : seoMetaArg.robots;

--- a/app/pages/[year]/index.vue
+++ b/app/pages/[year]/index.vue
@@ -1,9 +1,20 @@
 <script setup lang="ts">
+import type { AcceptedYear, SpeakerInfo } from '~~/types';
 import SpeakerTable from '~/components/SpeakerTable.vue';
 import { useFetchSpeaker } from '~/composables/speaker';
 
+type SpeakerWithYear = SpeakerInfo & { year: AcceptedYear };
+
 const route = useRoute();
 const { filterYearSpeaker } = await useFetchSpeaker(route.params.year as string);
+
+const speakersWithYear = computed<SpeakerWithYear[] | undefined>(() => {
+  if (!filterYearSpeaker?.value) return undefined;
+  return filterYearSpeaker.value.map(speaker => ({
+    ...speaker,
+    year: route.params.year as AcceptedYear,
+  }));
+});
 
 useHead({
   title: `Vue Fes Japan ${route.params.year as string}`,
@@ -42,7 +53,7 @@ useSeoMeta({
       </nuxt-link>
     </div>
     <div class="pt-6">
-      <SpeakerTable :speakers="filterYearSpeaker" :year="route.params.year as string" />
+      <SpeakerTable :speakers="speakersWithYear" :year="route.params.year as string" />
     </div>
   </div>
 </template>

--- a/app/pages/speakers/[name]/index.test.ts
+++ b/app/pages/speakers/[name]/index.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref } from 'vue';
+import { computed } from 'vue';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
+import type { AcceptedYear, SpeakerInfo } from '~~/types';
 import SpeakerNamePage from './index.vue';
 
 // Import mocked functions
 import { useFetchSpeaker } from '~/composables/speaker';
+
+type SpeakerWithYear = SpeakerInfo & { year: AcceptedYear };
 
 // Create hoisted mocks
 const { useSeoMetaMock, useHeadMock, useRouteMock } = vi.hoisted(() => {
@@ -43,15 +46,15 @@ const globalStubs = {
 };
 
 describe('speakers/[name]/index.vue', () => {
-  const mockSpeakers = [
+  const mockSpeakers: SpeakerWithYear[] = [
     {
-      year: '2024',
+      year: '2024' as AcceptedYear,
       name: ['John Doe'],
       title: 'Vue.js Advanced',
       url: 'https://example.com/talk1',
     },
     {
-      year: '2023',
+      year: '2023' as AcceptedYear,
       name: ['John Doe'],
       title: 'Nuxt 3 Deep Dive',
       url: 'https://example.com/talk2',
@@ -76,14 +79,14 @@ describe('speakers/[name]/index.vue', () => {
     // Set default mock implementation
     vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
       filterYearSpeaker: undefined,
-      filterNameSpeaker: ref([]),
+      filterNameSpeaker: computed(() => []),
     }));
   });
 
   it('スピーカー名とトークを含むページをレンダリングする', async () => {
     vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
       filterYearSpeaker: undefined,
-      filterNameSpeaker: ref(mockSpeakers),
+      filterNameSpeaker: computed(() => mockSpeakers),
     }));
 
     const wrapper = await mountSuspended(SpeakerNamePage, {
@@ -107,7 +110,7 @@ describe('speakers/[name]/index.vue', () => {
   it('スピーカーが存在しない場合、"Page not found"をレンダリングする', async () => {
     vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
       filterYearSpeaker: undefined,
-      filterNameSpeaker: ref([]),
+      filterNameSpeaker: computed(() => []),
     }));
 
     const wrapper = await mountSuspended(SpeakerNamePage, {
@@ -133,7 +136,7 @@ describe('speakers/[name]/index.vue', () => {
     // the actual parameter might not be accessible
     vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
       filterYearSpeaker: undefined,
-      filterNameSpeaker: ref(mockSpeakers),
+      filterNameSpeaker: computed(() => mockSpeakers),
     }));
 
     await mountSuspended(SpeakerNamePage, {
@@ -150,7 +153,7 @@ describe('speakers/[name]/index.vue', () => {
     it('スピーカーが存在する場合、robotsをindexに設定する', async () => {
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
         filterYearSpeaker: undefined,
-        filterNameSpeaker: ref(mockSpeakers),
+        filterNameSpeaker: computed(() => mockSpeakers),
       }));
 
       // mountSuspended を使用してNuxtコンテキストでコンポーネントをマウント
@@ -164,7 +167,7 @@ describe('speakers/[name]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       // useSeoMetaに渡された引数を取得
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
 
       // robotsプロパティが関数の場合は実行して値を取得
       const robotsValue = typeof seoMetaArg.robots === 'function'
@@ -178,7 +181,7 @@ describe('speakers/[name]/index.vue', () => {
     it('スピーカーが存在しない場合、robotsをnoindexに設定する', async () => {
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
         filterYearSpeaker: undefined,
-        filterNameSpeaker: ref([]),
+        filterNameSpeaker: computed(() => []),
       }));
 
       // mountSuspended を使用してNuxtコンテキストでコンポーネントをマウント
@@ -192,7 +195,7 @@ describe('speakers/[name]/index.vue', () => {
       expect(useSeoMetaMock).toHaveBeenCalled();
 
       // useSeoMetaに渡された引数を取得
-      const seoMetaArg = useSeoMetaMock.mock.calls[0][0];
+      const seoMetaArg = useSeoMetaMock.mock.calls[0]?.[0];
 
       // robotsプロパティが関数の場合は実行して値を取得
       const robotsValue = typeof seoMetaArg.robots === 'function'
@@ -206,7 +209,7 @@ describe('speakers/[name]/index.vue', () => {
     it('useHeadでタイトルが設定される', async () => {
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
         filterYearSpeaker: undefined,
-        filterNameSpeaker: ref(mockSpeakers),
+        filterNameSpeaker: computed(() => mockSpeakers),
       }));
 
       await mountSuspended(SpeakerNamePage, {
@@ -230,9 +233,9 @@ describe('speakers/[name]/index.vue', () => {
       const routeJapanese = { params: { name: '山田太郎' } };
       useRouteMock.mockReturnValue(routeJapanese);
 
-      const speakersJapanese = [
+      const speakersJapanese: SpeakerWithYear[] = [
         {
-          year: '2024',
+          year: '2024' as AcceptedYear,
           name: ['山田太郎'],
           title: 'Vue.jsの基礎',
           url: 'https://example.com/jp1',
@@ -241,7 +244,7 @@ describe('speakers/[name]/index.vue', () => {
 
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
         filterYearSpeaker: undefined,
-        filterNameSpeaker: ref(speakersJapanese),
+        filterNameSpeaker: computed(() => speakersJapanese),
       }));
 
       const wrapper = await mountSuspended(SpeakerNamePage, {
@@ -264,7 +267,7 @@ describe('speakers/[name]/index.vue', () => {
 
       vi.mocked(useFetchSpeaker).mockImplementation(() => Promise.resolve({
         filterYearSpeaker: undefined,
-        filterNameSpeaker: ref([]),
+        filterNameSpeaker: computed(() => []),
       }));
 
       const wrapper = await mountSuspended(SpeakerNamePage, {

--- a/app/pages/speakers/[name]/index.vue
+++ b/app/pages/speakers/[name]/index.vue
@@ -11,7 +11,7 @@ useHead({
 
 useSeoMeta({
   robots: () => {
-    if (!filterNameSpeaker.value || filterNameSpeaker.value.length === 0) {
+    if (!filterNameSpeaker?.value || filterNameSpeaker.value.length === 0) {
       return 'noindex';
     }
     return 'index';

--- a/server/api/speakers.ts
+++ b/server/api/speakers.ts
@@ -1,7 +1,7 @@
 import type { SpeakerInfo } from '~~/types';
 import { useFetchAllSpeakers } from '~/composables/speaker';
 
-export default defineEventHandler(async (): SpeakerInfo[] => {
+export default defineEventHandler(async (): Promise<SpeakerInfo[]> => {
   // Fetch all speakers with year information
   const allSpeakers = await useFetchAllSpeakers();
   return allSpeakers;


### PR DESCRIPTION
- undefined可能性のある値に対する適切な型ガード追加
- Ref型とComputedRef型の不一致を解消
- SpeakerInfo[]とSpeakerWithYear[]の型変換を実装
- AcceptedYear型の適切なインポートと使用
- async関数の戻り値にPromise型を明示的に指定

🤖 Generated with [Claude Code](https://claude.ai/code)