### PR TITLE
fix: correct speaker name for Naoki Haba

### DIFF
--- a/server/data/speakers-2025.ts
+++ b/server/data/speakers-2025.ts
@@ -85,7 +85,7 @@ export const speakers2025: SpeakerInfo[] = [
     url: 'https://vuefes.jp/2025/speaker/ssssota',
   },
   {
-    name: ['波場 直輝'],
+    name: ['羽馬 直樹'],
     title: 'Nuxt4のSingleton Data Fetching Layerで何が変わるのか',
     url: 'https://vuefes.jp/2025/speaker/NaokiHaba',
   },


### PR DESCRIPTION
### 📚 Description

Fixed a typo in the speaker's name for Vue Fes Japan 2025. 🙇

  Changes made:
  - Corrected the speaker name from "波場 直輝" to "羽馬 直樹" in server/data/speakers-2025.ts