### PR TITLE
Add Nuxt accessibility module a11y

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,7 +3,7 @@ import { defineNuxtConfig } from 'nuxt/config';
 export default defineNuxtConfig({
 
   // https://nuxt.com/modules
-  modules: ['@nuxthub/core', '@nuxt/eslint', '@nuxt/ui'],
+  modules: ['@nuxthub/core', '@nuxt/eslint', '@nuxt/ui', '@nuxt/a11y'],
 
   // https://devtools.nuxt.com
   devtools: { enabled: true },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@iconify-json/lucide": "catalog:icon",
+    "@nuxt/a11y": "1.0.0-alpha.1",
     "@nuxt/eslint": "catalog:test",
     "@nuxt/eslint-config": "catalog:test",
     "@nuxt/test-utils": "catalog:test",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@iconify-json/lucide": "catalog:icon",
-    "@nuxt/a11y": "1.0.0-alpha.1",
+    "@nuxt/a11y": "catalog:nuxt",
     "@nuxt/eslint": "catalog:test",
     "@nuxt/eslint-config": "catalog:test",
     "@nuxt/test-utils": "catalog:test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
       specifier: 1.2.84
       version: 1.2.84
   nuxt:
+    '@nuxt/a11y':
+      specifier: 1.0.0-alpha.1
+      version: 1.0.0-alpha.1
     '@nuxt/ui':
       specifier: 4.3.0
       version: 4.3.0
@@ -91,7 +94,7 @@ importers:
         specifier: catalog:icon
         version: 1.2.84
       '@nuxt/a11y':
-        specifier: 1.0.0-alpha.1
+        specifier: catalog:nuxt
         version: 1.0.0-alpha.1(magicast@0.5.1)(vite@7.2.7(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/eslint':
         specifier: catalog:test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@iconify-json/lucide':
         specifier: catalog:icon
         version: 1.2.84
+      '@nuxt/a11y':
+        specifier: 1.0.0-alpha.1
+        version: 1.0.0-alpha.1(magicast@0.5.1)(vite@7.2.7(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/eslint':
         specifier: catalog:test
         version: 1.11.0(@typescript-eslint/utils@8.48.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.26)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.7(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -1113,6 +1116,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nuxt/a11y@1.0.0-alpha.1':
+    resolution: {integrity: sha512-TwON9I0uI4erv9IJ6cD4nx9QcaxfXnAg7CwcQyjMKfDHCfI3xitezg4CZhQOHl0FGqHYGRf9Y9kSwh6fahCJrQ==}
 
   '@nuxt/cli@3.31.1':
     resolution: {integrity: sha512-2Quw4bQlVpMGS/AD34KUEsd4i5PVz993e//km10fYR3AKiilYCHiY+vYdvU9odtFYzmr3tQtfZb1rFfb3GUiCQ==}
@@ -2847,6 +2853,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axe-core@4.11.1:
+    resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+    engines: {node: '>=4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -6793,6 +6803,16 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@nuxt/a11y@1.0.0-alpha.1(magicast@0.5.1)(vite@7.2.7(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.7(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      axe-core: 4.11.1
+      sirv: 3.0.2
+    transitivePeerDependencies:
+      - magicast
+      - vite
+
   '@nuxt/cli@3.31.1(cac@6.7.14)(magicast@0.5.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.9(cac@6.7.14)(citty@0.1.6)
@@ -8868,6 +8888,8 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  axe-core@4.11.1: {}
 
   b4a@1.7.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ catalogs:
     '@iconify-json/heroicons-solid': 1.2.1
     '@iconify-json/lucide': 1.2.84
   nuxt:
+    '@nuxt/a11y': 1.0.0-alpha.1
     '@nuxt/ui': 4.3.0
     nuxt: 4.2.1
   test:


### PR DESCRIPTION
Added the official Nuxt accessibility module to enhance the application's accessibility features and compliance with WCAG standards.

Changes:
- Installed @nuxt/a11y (v1.0.0-alpha.1) as a dev dependency
- Added @nuxt/a11y to the modules array in nuxt.config.ts
- Updated pnpm-lock.yaml with new dependencies