### PR TITLE
fix: TOP の SSR ハイドレーション不一致を解消

### DIFF
--- a/app/components/ChronicleView.vue
+++ b/app/components/ChronicleView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { compareLexicalJa } from '~/utils/stringCollate';
 import { YEARS } from '~~/types';
 import type { SpeakerWithYear, AcceptedYear } from '~~/types';
 
@@ -20,7 +21,7 @@ const { t, lang } = useVfjsI18n();
 const uniqueNames = computed(() => {
   const set = new Set<string>();
   props.allSpeakers.forEach((s) => s.name.forEach((n) => set.add(n)));
-  return Array.from(set).sort((a, b) => a.localeCompare(b));
+  return Array.from(set).sort(compareLexicalJa);
 });
 
 const counts = computed(() => {

--- a/app/components/DirectoryView.vue
+++ b/app/components/DirectoryView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { compareLexicalJa } from '~/utils/stringCollate';
 import { buildSpeakerMap, hasJapanese } from '~/utils/speakerMap';
 import type { SpeakerRecord } from '~/utils/speakerMap';
 import { YEARS } from '~~/types';
@@ -49,16 +50,16 @@ const filtered = computed<SpeakerRecord[]>(() => {
     list = [...list].sort(
       (a, b) =>
         b.talks.length - a.talks.length ||
-        a.years[0]?.localeCompare(b.years[0] || '') ||
-        a.name.localeCompare(b.name),
+        compareLexicalJa(a.years[0] || '', b.years[0] || '') ||
+        compareLexicalJa(a.name, b.name),
     );
   } else if (sort.value === 'name') {
-    list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+    list = [...list].sort((a, b) => compareLexicalJa(a.name, b.name));
   } else if (sort.value === 'latest') {
     list = [...list].sort(
       (a, b) =>
-        b.years[b.years.length - 1]?.localeCompare(a.years[a.years.length - 1] || '') ||
-        a.name.localeCompare(b.name),
+        compareLexicalJa(b.years[b.years.length - 1] || '', a.years[a.years.length - 1] || '') ||
+        compareLexicalJa(a.name, b.name),
     );
   }
   return list;

--- a/app/composables/speaker.ts
+++ b/app/composables/speaker.ts
@@ -1,6 +1,8 @@
 import type { SpeakerInfo, AcceptedYear, SpeakerWithYear } from '~~/types';
 import { isValidYear } from '~/utils/years';
 
+const ALL_SPEAKERS_KEY = 'vfjs:all-speakers';
+
 const normalize = (s: string) => s.toLowerCase().trim();
 
 const fetchYearSpeakers = async (year: string) => {
@@ -9,9 +11,10 @@ const fetchYearSpeakers = async (year: string) => {
 };
 
 const fetchAllSpeakersWithYears = async () => {
-  // Single call to aggregated API
-  const all = await $fetch<SpeakerWithYear[]>(`/api/speakers`);
-  return all;
+  const { data } = await useAsyncData(ALL_SPEAKERS_KEY, () =>
+    $fetch<SpeakerWithYear[]>(`/api/speakers`),
+  );
+  return data.value ?? [];
 };
 
 const fetchNameSpeakers = async (name?: string) => {
@@ -36,10 +39,10 @@ export const useFetchSpeaker = async (params?: string) => {
   return handler(params);
 };
 
-export const useFetchAllSpeakers = async () => {
-  const allSpeakers = await fetchAllSpeakersWithYears();
-  return allSpeakers;
-};
+export const useFetchAllSpeakers = () =>
+  useAsyncData(ALL_SPEAKERS_KEY, () => $fetch<SpeakerWithYear[]>(`/api/speakers`), {
+    default: () => [],
+  });
 
 export const useFilteredSpeakers = (
   allSpeakers: Ref<SpeakerWithYear[]>,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -3,7 +3,7 @@ import { useFetchAllSpeakers } from '~/composables/speaker';
 import { YEARS } from '~~/types';
 import type { AcceptedYear } from '~~/types';
 
-const allSpeakers = await useFetchAllSpeakers();
+const { data: allSpeakers } = await useFetchAllSpeakers();
 
 const { t } = useVfjsI18n();
 
@@ -29,9 +29,10 @@ const selectedSpeaker = ref<string>('all');
 const query = ref('');
 
 const stats = computed(() => {
+  const list = allSpeakers.value;
   const speakerSet = new Set<string>();
-  for (const s of allSpeakers) s.name.forEach((n) => speakerSet.add(n));
-  return { speakers: speakerSet.size, talks: allSpeakers.length, years: YEARS.length };
+  for (const s of list) s.name.forEach((n) => speakerSet.add(n));
+  return { speakers: speakerSet.size, talks: list.length, years: YEARS.length };
 });
 </script>
 

--- a/app/pages/speakers/[name]/index.vue
+++ b/app/pages/speakers/[name]/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useFetchSpeaker } from '~/composables/speaker';
+import { compareLexicalJa } from '~/utils/stringCollate';
 import { hasJapanese } from '~/utils/speakerMap';
 
 const route = useRoute();
@@ -35,7 +36,7 @@ const record = computed(() => {
       url: s.url,
       coSpeakers: s.name.filter((n) => n !== speakerName),
     }))
-    .sort((a, b) => a.year.localeCompare(b.year));
+    .sort((a, b) => compareLexicalJa(a.year, b.year));
   const years = [...new Set(talks.map((tk) => tk.year))].sort();
   return { name: speakerName, nameRuby, nameEn, years, talks };
 });

--- a/app/utils/speakerMap.ts
+++ b/app/utils/speakerMap.ts
@@ -1,3 +1,4 @@
+import { compareLexicalJa } from '~/utils/stringCollate';
 import type { SpeakerWithYear } from '~~/types';
 
 export interface SpeakerRecord {
@@ -34,7 +35,7 @@ export function buildSpeakerMap(allSpeakers: SpeakerWithYear[]): Map<string, Spe
     }
   }
   for (const rec of map.values()) {
-    rec.talks.sort((a, b) => a.year.localeCompare(b.year));
+    rec.talks.sort((a, b) => compareLexicalJa(a.year, b.year));
     rec.years.sort();
   }
   return map;

--- a/app/utils/stringCollate.ts
+++ b/app/utils/stringCollate.ts
@@ -1,0 +1,7 @@
+/**
+ * Node（SSR）とブラウザで並び順がずれないよう、ロケールを固定した比較。
+ * TOP のスピーカー名ソート等でハイドレーション不一致を防ぐ。
+ */
+export function compareLexicalJa(a: string, b: string): number {
+  return a.localeCompare(b, 'ja', { sensitivity: 'accent', numeric: true });
+}


### PR DESCRIPTION
- 全件取得を useAsyncData でキー共有し SSR とクライアントのデータを一致
- localeCompare を ja 固定の compareLexicalJa に統一し Node/ブラウザの並び差を防止
- index の stats は allSpeakers の Ref を参照するよう変更