### PR TITLE
fix: カラーモード変更時のページ遷移チラつきを修正

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -115,6 +115,11 @@ export default defineApp({
       },
     ],
     stylesheets: import.meta.env.DEV ? ["/app/assets/css/main.css"] : [],
+    scripts: [
+      {
+        children: `(function(){try{var s=localStorage.getItem('vfjs:color-scheme');if(s==='dark'||s==='light'){document.documentElement.setAttribute('data-color-scheme',s)}}catch(e){}})();`,
+      },
+    ],
   },
   routes: [
     defineRoute({


### PR DESCRIPTION
## Summary

- SSGで生成されたHTMLの `<head>` にブロッキングインラインスクリプトを追加
- Vueハイドレーション（`onMounted`）より前に `localStorage` からカラースキーム設定を読み込み、`data-color-scheme` 属性を `<html>` 要素に適用することでFOUC（Flash of Unstyled Content）を解消

## Background

静的サイト生成（SSG）では全ページが事前生成されるため、ページ遷移時に `<html>` に `data-color-scheme` 属性がない状態でHTMLが読み込まれる。`useColorScheme.ts` の初期化は `onMounted` で行われるため、ハイドレーション前にデフォルトのカラースキームで一瞬表示されてしまう（チラつき）。

## Changes

`app/app.ts` の `document.scripts` に以下のブロッキングインラインスクリプトを追加：

```js
(function(){
  try {
    var s = localStorage.getItem('vfjs:color-scheme');
    if (s === 'dark' || s === 'light') {
      document.documentElement.setAttribute('data-color-scheme', s);
    }
  } catch(e) {}
})();
```

- `type` 属性なし → 同期ブロッキングスクリプトとして実行（初回レンダリング前に適用）
- `try/catch` → プライベートブラウジング等で `localStorage` が利用不可でもエラーにならない
- `'dark'` / `'light'` のみチェック → `'system'` の場合は属性を付与しない（`useColorScheme.ts` と同じ挙動）

## Test plan

- [x] `pnpm build` が正常に完了すること
- [x] 生成された `dist/client/index.html` の `<head>` にインラインスクリプトが含まれていること
- [x] ダークモードに切り替え → 別ページへ遷移 → チラつきがないこと
- [x] ライトモード・システムモードでも正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)