### PR TITLE
feat: enable vapor mode benchmark

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
 const { t } = useVfjsI18n();

--- a/app/components/AppHeader.test.ts
+++ b/app/components/AppHeader.test.ts
@@ -1,6 +1,6 @@
-import { renderToString } from "@vue/server-renderer";
+import { vaporInteropPlugin } from "@vue/runtime-vapor";
 import { mount } from "@vue/test-utils";
-import { createSSRApp, nextTick } from "vue";
+import { nextTick } from "vue";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import AppHeader from "./AppHeader.vue";
 
@@ -13,23 +13,44 @@ describe("AppHeader", () => {
   });
 
   it("初回表示の配色セレクターでシステム設定を選択する", async () => {
-    const html = await renderToString(createSSRApp(AppHeader));
+    const host = document.createElement("div");
+    document.body.append(host);
+    mount(AppHeader, {
+      attachTo: host,
+      global: {
+        plugins: [vaporInteropPlugin],
+      },
+    });
+    await nextTick();
 
-    expect(html).toContain('<option value="system" selected>');
-    expect(html).not.toContain('<option value="light" selected>');
+    try {
+      const select = host.querySelector("select");
+      expect(select?.value).toBe("system");
+      expect(host.innerHTML).not.toContain('<option value="light" selected>');
+    } finally {
+      host.remove();
+    }
   });
 
   it("保存済みの配色設定をマウント後に反映する", async () => {
     localStorage.setItem(STORAGE_KEY, "light");
 
-    const wrapper = mount(AppHeader);
+    const host = document.createElement("div");
+    document.body.append(host);
+    mount(AppHeader, {
+      attachTo: host,
+      global: {
+        plugins: [vaporInteropPlugin],
+      },
+    });
     await nextTick();
 
-    const select = wrapper.find("select").element as HTMLSelectElement;
+    const select = host.querySelector("select") as HTMLSelectElement;
     expect(select.value).toBe("light");
     expect(document.documentElement.getAttribute("data-color-scheme")).toBe("light");
 
-    await wrapper.find("select").setValue("system");
-    wrapper.unmount();
+    select.value = "system";
+    select.dispatchEvent(new Event("change"));
+    host.remove();
   });
 });

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
 import AppLogoMark from "./AppLogoMark.vue";
 import { useColorScheme } from "../composables/useColorScheme";
 import { useVfjsI18n } from "../composables/useVfjsI18n";

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -20,7 +20,9 @@ const { scheme, setScheme } = useColorScheme();
         href="/"
         class="flex items-center gap-[10px] font-display font-semibold text-[15px] whitespace-nowrap leading-[1.15] text-ink no-underline hover:text-accent transition-colors"
       >
-        <AppLogoMark class="w-4 h-auto text-ink" />
+        <span class="contents">
+          <AppLogoMark class="w-4 h-auto text-ink" />
+        </span>
         <span>Vue Fes Japan Speakers</span>
       </a>
 

--- a/app/components/AppLogoMark.vue
+++ b/app/components/AppLogoMark.vue
@@ -1,3 +1,5 @@
+<script setup vapor lang="ts"></script>
+
 <template>
   <svg
     aria-hidden="true"

--- a/app/components/AppMasthead.vue
+++ b/app/components/AppMasthead.vue
@@ -1,11 +1,13 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
+import { toRefs } from "vue";
 import AppLogoMark from "./AppLogoMark.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-defineProps<{
+const props = defineProps<{
   stats: { speakers: number; talks: number; years: number };
 }>();
 
+const { stats } = toRefs(props);
 const { t } = useVfjsI18n();
 </script>
 

--- a/app/components/AppMasthead.vue
+++ b/app/components/AppMasthead.vue
@@ -1,13 +1,11 @@
 <script setup vapor lang="ts">
-import { toRefs } from "vue";
 import AppLogoMark from "./AppLogoMark.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { stats } = defineProps<{
   stats: { speakers: number; talks: number; years: number };
 }>();
 
-const { stats } = toRefs(props);
 const { t } = useVfjsI18n();
 </script>
 
@@ -20,7 +18,9 @@ const { t } = useVfjsI18n();
       <div
         class="basis-0 grow-999 min-inline-[60%] flex flex-wrap items-center gap-[clamp(18px,2.4vw,34px)]"
       >
-        <AppLogoMark class="basis-15 grow-1 max-w-[60px] h-auto text-ink" />
+        <span class="contents">
+          <AppLogoMark class="basis-15 grow-1 max-w-[60px] h-auto text-ink" />
+        </span>
         <!-- ページタイトル -->
         <h1
           class="basis-0 grow-999 min-inline-[80%] m-0 font-display font-[500] text-[clamp(38px,6.2vw,104px)] leading-[0.96] text-ink break-keep"
@@ -35,23 +35,23 @@ const { t } = useVfjsI18n();
         <!-- 総スピーカー数 -->
         <div>
           <b class="text-ink font-[500] not-italic">
-            {{ stats.speakers }}
+            {{ $props.stats.speakers }}
           </b>
-          {{ t.meta_speakers }}
+          <span>{{ t.meta_speakers }}</span>
         </div>
         <!-- 総トーク数 -->
         <div>
           <b class="text-ink font-[500] not-italic">
-            {{ stats.talks }}
+            {{ $props.stats.talks }}
           </b>
-          {{ t.meta_talks }}
+          <span>{{ t.meta_talks }}</span>
         </div>
         <!-- 開催年数 -->
         <div>
           <b class="text-ink font-[500] not-italic">
-            {{ stats.years }}
+            {{ $props.stats.years }}
           </b>
-          {{ t.meta_years }}
+          <span>{{ t.meta_years }}</span>
         </div>
       </aside>
     </div>

--- a/app/components/ChronicleView.vue
+++ b/app/components/ChronicleView.vue
@@ -1,5 +1,5 @@
 <script setup vapor lang="ts">
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { YEARS } from "../../types";
@@ -7,25 +7,36 @@ import SpeakerFilterBar from "./SpeakerFilterBar.vue";
 import YearFilterBar from "./YearFilterBar.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { allSpeakers, query, selectedSpeaker, selectedYear } = defineProps<{
   allSpeakers: SpeakerWithYear[];
   selectedYear: AcceptedYear | "all";
   selectedSpeaker: string;
   query: string;
 }>();
 
-const { allSpeakers, query, selectedSpeaker, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
   "update:selectedSpeaker": [string];
   "update:query": [string];
 }>();
 
+function updateSelectedYear(value: AcceptedYear | "all") {
+  emit("update:selectedYear", value);
+}
+
+function updateSelectedSpeaker(value: string) {
+  emit("update:selectedSpeaker", value);
+}
+
+function updateQuery(value: string) {
+  emit("update:query", value);
+}
+
 const { t, lang } = useVfjsI18n();
 
 const uniqueNames = computed(() => {
   const set = new Set<string>();
-  props.allSpeakers.forEach((s) => s.name.forEach((n) => set.add(n)));
+  allSpeakers.forEach((s) => s.name.forEach((n) => set.add(n)));
   return Array.from(set).sort(compareLexicalJa);
 });
 
@@ -34,18 +45,18 @@ const speakerOptions = computed(() =>
 );
 
 const counts = computed(() => {
-  const c: Record<string, number> = { all: props.allSpeakers.length };
+  const c: Record<string, number> = { all: allSpeakers.length };
   for (const y of YEARS) {
-    c[y] = props.allSpeakers.filter((s) => s.year === y).length;
+    c[y] = allSpeakers.filter((s) => s.year === y).length;
   }
   return c;
 });
 
 const filtered = computed(() => {
-  const q = props.query.trim().toLowerCase();
-  return props.allSpeakers.filter((s) => {
-    if (props.selectedYear !== "all" && s.year !== props.selectedYear) return false;
-    if (props.selectedSpeaker !== "all" && !s.name.includes(props.selectedSpeaker)) return false;
+  const q = query.trim().toLowerCase();
+  return allSpeakers.filter((s) => {
+    if (selectedYear !== "all" && s.year !== selectedYear) return false;
+    if (selectedSpeaker !== "all" && !s.name.includes(selectedSpeaker)) return false;
     if (q) {
       const hay = (s.title || "") + " " + s.name.join(" ");
       if (!hay.toLowerCase().includes(q)) return false;
@@ -58,7 +69,9 @@ const grouped = computed(() => {
   const map = new Map<string, SpeakerWithYear[]>();
   for (const y of YEARS) map.set(y, []);
   for (const s of filtered.value) map.get(s.year)?.push(s);
-  return Array.from(map.entries()).filter(([, arr]) => arr.length > 0);
+  return Array.from(map.entries())
+    .filter(([, talks]) => talks.length > 0)
+    .map(([year, talks]) => ({ year, talks }));
 });
 </script>
 
@@ -66,20 +79,24 @@ const grouped = computed(() => {
   <main>
     <section>
       <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query="query"
-        :selected-speaker="selectedSpeaker"
-        :speaker-options="speakerOptions"
-        @update:query="emit('update:query', $event)"
-        @update:selected-speaker="emit('update:selectedSpeaker', $event)"
-      />
+      <div class="contents">
+        <SpeakerFilterBar
+          :query="$props.query"
+          :selected-speaker="$props.selectedSpeaker"
+          :speaker-options="speakerOptions"
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+        />
+      </div>
 
       <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar
-        :selected-year="selectedYear"
-        :counts="counts"
-        @update:selected-year="emit('update:selectedYear', $event)"
-      />
+      <div class="contents">
+        <YearFilterBar
+          :selected-year="$props.selectedYear"
+          :counts="counts"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
 
       <!-- フィルター結果が0件のとき -->
       <div
@@ -93,31 +110,31 @@ const grouped = computed(() => {
       <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
         <!-- 各年度グループ -->
         <li
-          v-for="[year, arr] in grouped"
-          :key="year"
+          v-for="group in grouped"
+          :key="group.year"
           class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
         >
           <!-- 年度ラベル（スクロール時に上部に固定） -->
           <div
             class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
-            :id="`year-${year}`"
+            :id="`year-${group.year}`"
           >
             <!-- 年度テキスト（表示専用） -->
             <span
               class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink"
               aria-hidden="true"
             >
-              {{ year }}
+              {{ group.year }}
             </span>
             <!-- その年のトーク総数 -->
             <span class="font-mono text-[12px] tracking-[0.08em] uppercase text-ink-3 mt-2.5">
-              {{ t.year_total_talks(arr.length) }}
+              {{ t.year_total_talks(group.talks.length) }}
             </span>
             <!-- 年度別ページへの矢印リンク -->
             <a
               class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-              :href="`/${year}`"
-              :aria-label="`${year} speakers`"
+              :href="`/${group.year}`"
+              :aria-label="`${group.year} speakers`"
             >
               →
             </a>
@@ -127,8 +144,8 @@ const grouped = computed(() => {
           <ol class="list-none p-0 m-0 border-t border-rule-soft">
             <!-- 各スピーカー行 -->
             <li
-              v-for="(s, i) in arr"
-              :key="`${year}-${i}`"
+              v-for="(s, i) in group.talks"
+              :key="`${group.year}-${i}`"
               class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
             >
               <!-- 行番号（表示専用） -->
@@ -147,7 +164,7 @@ const grouped = computed(() => {
                       :href="`/speakers/${encodeURIComponent(n)}`"
                     >
                       <ruby v-if="s.nameRuby?.[ni] && lang === 'ja'" lang="ja">
-                        {{ n }}
+                        <span>{{ n }}</span>
                         <rt>{{ s.nameRuby[ni] }}</rt>
                       </ruby>
                       <span v-else>{{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}</span>

--- a/app/components/ChronicleView.vue
+++ b/app/components/ChronicleView.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
-import { computed } from "vue";
+<script setup vapor lang="ts">
+import { computed, toRefs } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { YEARS } from "../../types";
@@ -14,6 +14,7 @@ const props = defineProps<{
   query: string;
 }>();
 
+const { allSpeakers, query, selectedSpeaker, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
   "update:selectedSpeaker": [string];

--- a/app/components/DirectoryView.vue
+++ b/app/components/DirectoryView.vue
@@ -1,5 +1,5 @@
 <script setup vapor lang="ts">
-import { computed, ref, toRefs } from "vue";
+import { computed, ref } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
@@ -9,23 +9,34 @@ import SpeakerFilterBar from "./SpeakerFilterBar.vue";
 import YearFilterBar from "./YearFilterBar.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { allSpeakers, query, selectedSpeaker, selectedYear } = defineProps<{
   allSpeakers: SpeakerWithYear[];
   selectedYear: AcceptedYear | "all";
   selectedSpeaker: string;
   query: string;
 }>();
 
-const { allSpeakers, query, selectedSpeaker, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
   "update:selectedSpeaker": [string];
   "update:query": [string];
 }>();
 
+function updateSelectedYear(value: AcceptedYear | "all") {
+  emit("update:selectedYear", value);
+}
+
+function updateSelectedSpeaker(value: string) {
+  emit("update:selectedSpeaker", value);
+}
+
+function updateQuery(value: string) {
+  emit("update:query", value);
+}
+
 const { t, lang } = useVfjsI18n();
 
-const speakerMap = computed(() => buildSpeakerMap(props.allSpeakers));
+const speakerMap = computed(() => buildSpeakerMap(allSpeakers));
 const allRecords = computed(() => Array.from(speakerMap.value.values()));
 const speakerOptions = computed(() =>
   allRecords.value.map((record) => ({
@@ -39,16 +50,16 @@ const sort = ref<"name-asc" | "name-desc" | "appearances" | "latest">("appearanc
 const counts = computed(() => {
   const c: Record<string, number> = { all: allRecords.value.length };
   for (const y of YEARS) {
-    c[y] = props.allSpeakers.filter((s) => s.year === y).length;
+    c[y] = allSpeakers.filter((s) => s.year === y).length;
   }
   return c;
 });
 
 const filtered = computed<SpeakerRecord[]>(() => {
-  const q = props.query.trim().toLowerCase();
+  const q = query.trim().toLowerCase();
   let list = allRecords.value.filter((rec) => {
-    if (props.selectedYear !== "all" && !rec.years.includes(props.selectedYear)) return false;
-    if (props.selectedSpeaker !== "all" && rec.name !== props.selectedSpeaker) return false;
+    if (selectedYear !== "all" && !rec.years.includes(selectedYear)) return false;
+    if (selectedSpeaker !== "all" && rec.name !== selectedSpeaker) return false;
     if (q) {
       const titles = rec.talks.map((tk) => tk.title || "").join(" ");
       const hay = (rec.name + " " + titles).toLowerCase();
@@ -93,20 +104,24 @@ function toggleRow(name: string) {
   <main>
     <section>
       <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query="query"
-        :selected-speaker="selectedSpeaker"
-        :speaker-options="speakerOptions"
-        @update:query="emit('update:query', $event)"
-        @update:selected-speaker="emit('update:selectedSpeaker', $event)"
-      />
+      <div class="contents">
+        <SpeakerFilterBar
+          :query="$props.query"
+          :selected-speaker="$props.selectedSpeaker"
+          :speaker-options="speakerOptions"
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+        />
+      </div>
 
       <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar
-        :selected-year="selectedYear"
-        :counts="counts"
-        @update:selected-year="emit('update:selectedYear', $event)"
-      />
+      <div class="contents">
+        <YearFilterBar
+          :selected-year="$props.selectedYear"
+          :counts="counts"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
 
       <!-- Sort header -->
       <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
@@ -192,7 +207,7 @@ function toggleRow(name: string) {
                 :lang="hasJapanese(rec.name) ? 'ja' : 'en'"
               >
                 <ruby v-if="rec.nameRuby && lang === 'ja'">
-                  {{ rec.name }}
+                  <span>{{ rec.name }}</span>
                   <rt>{{ rec.nameRuby }}</rt>
                 </ruby>
                 <template v-else>
@@ -218,7 +233,7 @@ function toggleRow(name: string) {
                   :key="y"
                   class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
                   :class="[
-                    rec.years.includes(y) && selectedYear === y
+                    rec.years.includes(y) && $props.selectedYear === y
                       ? 'bg-accent border border-accent text-white'
                       : rec.years.includes(y)
                         ? 'bg-ink border border-ink text-paper'

--- a/app/components/DirectoryView.vue
+++ b/app/components/DirectoryView.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
-import { computed, ref } from "vue";
+<script setup vapor lang="ts">
+import { computed, ref, toRefs } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
@@ -16,6 +16,7 @@ const props = defineProps<{
   query: string;
 }>();
 
+const { allSpeakers, query, selectedSpeaker, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
   "update:selectedSpeaker": [string];

--- a/app/components/SpeakerFilterBar.vue
+++ b/app/components/SpeakerFilterBar.vue
@@ -1,12 +1,14 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
+import { toRefs } from "vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-defineProps<{
+const props = defineProps<{
   query: string;
   selectedSpeaker: string;
   speakerOptions: Array<{ label: string; value: string }>;
 }>();
 
+const { query, selectedSpeaker, speakerOptions } = toRefs(props);
 const emit = defineEmits<{
   "update:query": [string];
   "update:selectedSpeaker": [string];

--- a/app/components/SpeakerFilterBar.vue
+++ b/app/components/SpeakerFilterBar.vue
@@ -1,14 +1,12 @@
 <script setup vapor lang="ts">
-import { toRefs } from "vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { query, selectedSpeaker, speakerOptions } = defineProps<{
   query: string;
   selectedSpeaker: string;
   speakerOptions: Array<{ label: string; value: string }>;
 }>();
 
-const { query, selectedSpeaker, speakerOptions } = toRefs(props);
 const emit = defineEmits<{
   "update:query": [string];
   "update:selectedSpeaker": [string];
@@ -37,7 +35,7 @@ const speakerId = "speaker-filter-speaker";
         type="search"
         class="bg-transparent border-0 border-b border-rule-soft px-0 py-[8px] font-body text-[15px] text-ink outline-none focus:border-accent w-full"
         :placeholder="t.filter_search_ph"
-        :value="query"
+        :value="$props.query"
         @input="emit('update:query', ($event.target as HTMLInputElement).value)"
       />
     </div>
@@ -54,11 +52,11 @@ const speakerId = "speaker-filter-speaker";
       <select
         :id="speakerId"
         class="bg-transparent border-0 border-b border-rule-soft px-0 pr-6 py-2 font-body text-[15px] text-ink cursor-pointer outline-none w-full focus:border-accent"
-        :value="selectedSpeaker"
+        :value="$props.selectedSpeaker"
         @change="emit('update:selectedSpeaker', ($event.target as HTMLSelectElement).value)"
       >
         <option value="all">{{ t.filter_all_speakers }}</option>
-        <option v-for="option in speakerOptions" :key="option.value" :value="option.value">
+        <option v-for="option in $props.speakerOptions" :key="option.value" :value="option.value">
           {{ option.label }}
         </option>
       </select>

--- a/app/components/YearFilterBar.vue
+++ b/app/components/YearFilterBar.vue
@@ -1,13 +1,15 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
+import { toRefs } from "vue";
 import { YEARS } from "../../types";
 import type { AcceptedYear } from "../../types";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-defineProps<{
+const props = defineProps<{
   selectedYear: AcceptedYear | "all";
   counts: Record<string, number>;
 }>();
 
+const { counts, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
 }>();

--- a/app/components/YearFilterBar.vue
+++ b/app/components/YearFilterBar.vue
@@ -1,15 +1,13 @@
 <script setup vapor lang="ts">
-import { toRefs } from "vue";
 import { YEARS } from "../../types";
 import type { AcceptedYear } from "../../types";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { counts, selectedYear } = defineProps<{
   selectedYear: AcceptedYear | "all";
   counts: Record<string, number>;
 }>();
 
-const { counts, selectedYear } = toRefs(props);
 const emit = defineEmits<{
   "update:selectedYear": [AcceptedYear | "all"];
 }>();
@@ -30,14 +28,14 @@ const { t } = useVfjsI18n();
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule-soft cursor-pointer transition-colors"
           type="button"
           :class="
-            selectedYear === 'all'
+            $props.selectedYear === 'all'
               ? 'bg-ink text-paper border-ink'
               : 'text-ink-2 hover:border-ink hover:text-ink'
           "
-          :data-active="selectedYear === 'all' ? 'true' : 'false'"
+          :data-active="$props.selectedYear === 'all' ? 'true' : 'false'"
           @click="emit('update:selectedYear', 'all')"
         >
-          ALL · {{ counts.all }}
+          ALL · {{ $props.counts.all }}
         </button>
         <!-- 各開催年ごとの選択ボタン（その年のスピーカー数を表示） -->
         <button
@@ -46,14 +44,14 @@ const { t } = useVfjsI18n();
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule-soft cursor-pointer transition-colors"
           type="button"
           :class="
-            selectedYear === y
+            $props.selectedYear === y
               ? 'bg-ink text-paper border-ink'
               : 'text-ink-2 hover:border-ink hover:text-ink'
           "
-          :data-active="selectedYear === y ? 'true' : 'false'"
+          :data-active="$props.selectedYear === y ? 'true' : 'false'"
           @click="emit('update:selectedYear', y)"
         >
-          {{ y }} · {{ counts[y] }}
+          {{ y }} · {{ $props.counts[y] }}
         </button>
       </div>
     </div>

--- a/app/island-definitions.ts
+++ b/app/island-definitions.ts
@@ -1,16 +1,17 @@
 import { defineIsland, type JsonObject } from "@vuerend/core";
 
+// Vapor SSR hydration is not stable yet; mount over SSR HTML after the page becomes idle.
 export const HomePageIsland = defineIsland<JsonObject>("home-page", {
   load: () => import("./islands/HomePageIsland.vue"),
-  hydrate: "load",
+  hydrate: "idle",
 });
 
 export const YearPageIsland = defineIsland<JsonObject>("year-page", {
   load: () => import("./islands/YearPageIsland.vue"),
-  hydrate: "load",
+  hydrate: "idle",
 });
 
 export const SpeakerPageIsland = defineIsland<JsonObject>("speaker-page", {
   load: () => import("./islands/SpeakerPageIsland.vue"),
-  hydrate: "load",
+  hydrate: "idle",
 });

--- a/app/islands/HomePageIsland.vue
+++ b/app/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
 <script setup vapor lang="ts">
-import { computed, onMounted, ref, toRefs, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -9,11 +9,10 @@ import ChronicleView from "../components/ChronicleView.vue";
 import DirectoryView from "../components/DirectoryView.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { allSpeakers } = defineProps<{
   allSpeakers: SpeakerWithYear[];
 }>();
 
-const { allSpeakers } = toRefs(props);
 const { t } = useVfjsI18n();
 
 const view = ref<"chronicle" | "index">("chronicle");
@@ -31,14 +30,26 @@ const selectedYear = ref<AcceptedYear | "all">("all");
 const selectedSpeaker = ref<string>("all");
 const query = ref("");
 
+function updateSelectedYear(value: AcceptedYear | "all") {
+  selectedYear.value = value;
+}
+
+function updateSelectedSpeaker(value: string) {
+  selectedSpeaker.value = value;
+}
+
+function updateQuery(value: string) {
+  query.value = value;
+}
+
 const stats = computed(() => {
   const speakerSet = new Set<string>();
-  for (const speaker of props.allSpeakers) {
+  for (const speaker of allSpeakers) {
     speaker.name.forEach((name) => speakerSet.add(name));
   }
   return {
     speakers: speakerSet.size,
-    talks: props.allSpeakers.length,
+    talks: allSpeakers.length,
     years: YEARS.length,
   };
 });
@@ -46,10 +57,14 @@ const stats = computed(() => {
 
 <template>
   <div>
-    <AppHeader />
+    <div class="contents">
+      <AppHeader />
+    </div>
 
     <!-- タイトル・統計情報 -->
-    <AppMasthead :stats="stats" />
+    <div class="contents">
+      <AppMasthead :stats="stats" />
+    </div>
 
     <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
     <div
@@ -91,28 +106,32 @@ const stats = computed(() => {
 
     <!-- 選択中のビューに応じてコンポーネントを切り替え -->
     <!-- 年度別クロニクルビュー -->
-    <ChronicleView
-      v-if="view === 'chronicle'"
-      :all-speakers="allSpeakers"
-      :selected-year="selectedYear"
-      :selected-speaker="selectedSpeaker"
-      :query="query"
-      @update:selected-year="selectedYear = $event"
-      @update:selected-speaker="selectedSpeaker = $event"
-      @update:query="query = $event"
-    />
+    <div v-if="view === 'chronicle'" class="contents">
+      <ChronicleView
+        :all-speakers="$props.allSpeakers"
+        :selected-year="selectedYear"
+        :selected-speaker="selectedSpeaker"
+        :query="query"
+        @update:selected-year="updateSelectedYear"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:query="updateQuery"
+      />
+    </div>
     <!-- スピーカー索引ディレクトリビュー -->
-    <DirectoryView
-      v-else
-      :all-speakers="allSpeakers"
-      :selected-year="selectedYear"
-      :selected-speaker="selectedSpeaker"
-      :query="query"
-      @update:selected-year="selectedYear = $event"
-      @update:selected-speaker="selectedSpeaker = $event"
-      @update:query="query = $event"
-    />
+    <div v-else class="contents">
+      <DirectoryView
+        :all-speakers="$props.allSpeakers"
+        :selected-year="selectedYear"
+        :selected-speaker="selectedSpeaker"
+        :query="query"
+        @update:selected-year="updateSelectedYear"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:query="updateQuery"
+      />
+    </div>
 
-    <AppFooter />
+    <div class="contents">
+      <AppFooter />
+    </div>
   </div>
 </template>

--- a/app/islands/HomePageIsland.vue
+++ b/app/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+<script setup vapor lang="ts">
+import { computed, onMounted, ref, toRefs, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -13,6 +13,7 @@ const props = defineProps<{
   allSpeakers: SpeakerWithYear[];
 }>();
 
+const { allSpeakers } = toRefs(props);
 const { t } = useVfjsI18n();
 
 const view = ref<"chronicle" | "index">("chronicle");

--- a/app/islands/SpeakerPageIsland.test.ts
+++ b/app/islands/SpeakerPageIsland.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vite-plus/test";
 import { mount } from "@vue/test-utils";
+import { vaporInteropPlugin } from "@vue/runtime-vapor";
 import SpeakerPageIsland from "./SpeakerPageIsland.vue";
 
 describe("SpeakerPageIsland", () => {
   it("スピーカー名と発表一覧をレンダリングする", () => {
-    const wrapper = mount(SpeakerPageIsland, {
+    const host = document.createElement("div");
+    document.body.append(host);
+    mount(SpeakerPageIsland, {
+      attachTo: host,
+      global: {
+        plugins: [vaporInteropPlugin],
+      },
       props: {
         found: true,
         speakerName: "John Doe",
@@ -25,10 +32,14 @@ describe("SpeakerPageIsland", () => {
       },
     });
 
-    expect(wrapper.html()).toContain("John Doe");
-    expect(wrapper.html()).toContain("Vue 3 Deep Dive");
-    expect(wrapper.html()).toContain("Vue.js Advanced");
-    expect(wrapper.html()).toContain("2023");
-    expect(wrapper.html()).toContain("2024");
+    try {
+      expect(host.innerHTML).toContain("John Doe");
+      expect(host.innerHTML).toContain("Vue 3 Deep Dive");
+      expect(host.innerHTML).toContain("Vue.js Advanced");
+      expect(host.innerHTML).toContain("2023");
+      expect(host.innerHTML).toContain("2024");
+    } finally {
+      host.remove();
+    }
   });
 });

--- a/app/islands/SpeakerPageIsland.vue
+++ b/app/islands/SpeakerPageIsland.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
-import { computed } from "vue";
+<script setup vapor lang="ts">
+import { computed, toRefs } from "vue";
 import type { SpeakerWithYear } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
@@ -13,6 +13,7 @@ const props = defineProps<{
   speakers: SpeakerWithYear[];
 }>();
 
+const { found, speakerName, speakers } = toRefs(props);
 const { t, lang } = useVfjsI18n();
 
 const record = computed(() => {

--- a/app/islands/SpeakerPageIsland.vue
+++ b/app/islands/SpeakerPageIsland.vue
@@ -1,5 +1,5 @@
 <script setup vapor lang="ts">
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 import type { SpeakerWithYear } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
@@ -7,46 +7,47 @@ import { useVfjsI18n } from "../composables/useVfjsI18n";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { hasJapanese } from "../utils/speakerMap";
 
-const props = defineProps<{
+const { found, speakerName, speakers } = defineProps<{
   found: boolean;
   speakerName: string;
   speakers: SpeakerWithYear[];
 }>();
 
-const { found, speakerName, speakers } = toRefs(props);
 const { t, lang } = useVfjsI18n();
 
 const record = computed(() => {
   let nameRuby: string | undefined;
   let nameEn: string | undefined;
-  for (const speaker of props.speakers) {
-    const index = speaker.name.indexOf(props.speakerName);
+  for (const speaker of speakers) {
+    const index = speaker.name.indexOf(speakerName);
     if (index >= 0) {
       if (!nameRuby && speaker.nameRuby?.[index]) nameRuby = speaker.nameRuby[index];
       if (!nameEn && speaker.nameEn?.[index]) nameEn = speaker.nameEn[index];
       if (nameRuby && nameEn) break;
     }
   }
-  const talks = props.speakers
+  const talks = speakers
     .map((speaker) => ({
       year: speaker.year,
       title: speaker.title,
       url: speaker.url,
       format: speaker.format,
-      coSpeakers: speaker.name.filter((name) => name !== props.speakerName),
+      coSpeakers: speaker.name.filter((name) => name !== speakerName),
     }))
     .sort((a, b) => compareLexicalJa(a.year, b.year));
   const years = [...new Set(talks.map((talk) => talk.year))].sort();
-  return { name: props.speakerName, nameRuby, nameEn, years, talks };
+  return { name: speakerName, nameRuby, nameEn, years, talks };
 });
 </script>
 
 <template>
   <div>
-    <AppHeader />
+    <div class="contents">
+      <AppHeader />
+    </div>
 
     <!-- スピーカーページのメインコンテンツ（該当スピーカーが存在する場合） -->
-    <template v-if="found">
+    <template v-if="$props.found">
       <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
       <header
         class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x"
@@ -57,7 +58,7 @@ const record = computed(() => {
           :lang="hasJapanese(record.name) ? 'ja' : 'en'"
         >
           <ruby v-if="record.nameRuby && lang === 'ja'">
-            {{ record.name }}
+            <span>{{ record.name }}</span>
             <rt>{{ record.nameRuby }}</rt>
           </ruby>
           <template v-else>
@@ -147,9 +148,11 @@ const record = computed(() => {
     <!-- スピーカーが存在しない場合 -->
     <main v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
       <h1 class="font-display text-[40px] text-ink m-0">Speaker Not Found</h1>
-      <p>{{ speakerName }}</p>
+      <p>{{ $props.speakerName }}</p>
     </main>
 
-    <AppFooter />
+    <div class="contents">
+      <AppFooter />
+    </div>
   </div>
 </template>

--- a/app/islands/YearPageIsland.test.ts
+++ b/app/islands/YearPageIsland.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vite-plus/test";
 import { mount } from "@vue/test-utils";
+import { vaporInteropPlugin } from "@vue/runtime-vapor";
 import YearPageIsland from "./YearPageIsland.vue";
 
 describe("YearPageIsland", () => {
   it("年タイトルとスピーカーリストをレンダリングする", () => {
-    const wrapper = mount(YearPageIsland, {
+    const host = document.createElement("div");
+    document.body.append(host);
+    mount(YearPageIsland, {
+      attachTo: host,
+      global: {
+        plugins: [vaporInteropPlugin],
+      },
       props: {
         found: true,
         year: "2024",
@@ -18,9 +25,13 @@ describe("YearPageIsland", () => {
       },
     });
 
-    expect(wrapper.html()).toContain("Vue Fes Japan");
-    expect(wrapper.html()).toContain("2024");
-    expect(wrapper.html()).toContain("John Doe");
-    expect(wrapper.html()).toContain("Vue.js Advanced");
+    try {
+      expect(host.innerHTML).toContain("Vue Fes Japan");
+      expect(host.innerHTML).toContain("2024");
+      expect(host.innerHTML).toContain("John Doe");
+      expect(host.innerHTML).toContain("Vue.js Advanced");
+    } finally {
+      host.remove();
+    }
   });
 });

--- a/app/islands/YearPageIsland.vue
+++ b/app/islands/YearPageIsland.vue
@@ -1,26 +1,26 @@
 <script setup vapor lang="ts">
-import { toRefs } from "vue";
 import type { SpeakerInfo } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const props = defineProps<{
+const { found, speakers, year } = defineProps<{
   found: boolean;
   speakers: SpeakerInfo[];
   year: string;
 }>();
 
-const { found, speakers, year } = toRefs(props);
 const { t, lang } = useVfjsI18n();
 </script>
 
 <template>
   <div>
-    <AppHeader />
+    <div class="contents">
+      <AppHeader />
+    </div>
 
     <!-- 年度ページのメインコンテンツ（該当年度が存在する場合） -->
-    <main v-if="found">
+    <main v-if="$props.found">
       <!-- 年度ページのヘッダー（タイトル・トーク数・公式サイトリンク） -->
       <header
         class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x"
@@ -28,16 +28,16 @@ const { t, lang } = useVfjsI18n();
         <!-- 年度タイトル（2022年はオンライン開催のサブ表記付き） -->
         <h1 class="font-display text-[clamp(28px,4.5vw,72px)] font-[500] leading-[1] mb-4">
           Vue Fes Japan
-          <span v-if="year === '2022'">Online</span>
-          <em class="not-italic text-accent">{{ year }}</em>
+          <span v-if="$props.year === '2022'">Online</span>
+          <em class="not-italic text-accent">{{ $props.year }}</em>
         </h1>
         <div class="font-mono text-ink-3">
           <!-- その年のトーク総数 -->
-          <div>{{ t.year_total_talks(speakers.length) }}</div>
+          <div>{{ t.year_total_talks($props.speakers.length) }}</div>
           <!-- 公式サイトへの外部リンク -->
           <div class="mt-2 text-[12px]">
             <a
-              :href="`https://vuefes.jp/${year}/`"
+              :href="`https://vuefes.jp/${$props.year}/`"
               target="_blank"
               rel="noopener noreferrer"
               class="inline-block text-ink-2 no-underline group flex items-baseline gap-1"
@@ -57,7 +57,7 @@ const { t, lang } = useVfjsI18n();
         <ol class="list-none p-0 m-0">
           <!-- 各スピーカーの行 -->
           <li
-            v-for="(speaker, index) in speakers"
+            v-for="(speaker, index) in $props.speakers"
             :key="index"
             class="grid grid-cols-[40px_1fr] border-t border-rule-softer py-4.5"
           >
@@ -77,7 +77,7 @@ const { t, lang } = useVfjsI18n();
                     :href="`/speakers/${encodeURIComponent(name)}`"
                   >
                     <ruby v-if="speaker.nameRuby?.[nameIndex] && lang === 'ja'" lang="ja">
-                      {{ name }}
+                      <span>{{ name }}</span>
                       <rt>{{ speaker.nameRuby[nameIndex] }}</rt>
                     </ruby>
                     <span v-else>
@@ -121,10 +121,12 @@ const { t, lang } = useVfjsI18n();
     <!-- 年度が存在しない場合 -->
     <main v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
       <h1 class="font-display text-[40px] text-ink m-0">Year Not Found</h1>
-      <p>{{ year }}</p>
+      <p>{{ $props.year }}</p>
     </main>
 
     <!-- サイトフッター -->
-    <AppFooter />
+    <div class="contents">
+      <AppFooter />
+    </div>
   </div>
 </template>

--- a/app/islands/YearPageIsland.vue
+++ b/app/islands/YearPageIsland.vue
@@ -1,15 +1,17 @@
-<script setup lang="ts">
+<script setup vapor lang="ts">
+import { toRefs } from "vue";
 import type { SpeakerInfo } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-defineProps<{
+const props = defineProps<{
   found: boolean;
   speakers: SpeakerInfo[];
   year: string;
 }>();
 
+const { found, speakers, year } = toRefs(props);
 const { t, lang } = useVfjsI18n();
 </script>
 

--- a/app/runtime/vuerend-vapor-runtime.ts
+++ b/app/runtime/vuerend-vapor-runtime.ts
@@ -1,3 +1,3 @@
 // The published @vuerend/core@0.2.0 dist imports a bundled Vapor runtime chunk.
 // Route that import back to this app's Vue 3.6 runtime so server prerender can resolve it.
-export { vaporInteropPlugin as n, createVaporSSRApp as t } from "@vue/runtime-vapor";
+export { vaporInteropPlugin as n, createVaporApp as t } from "@vue/runtime-vapor";

--- a/app/runtime/vuerend-vapor-runtime.ts
+++ b/app/runtime/vuerend-vapor-runtime.ts
@@ -1,0 +1,3 @@
+// The published @vuerend/core@0.2.0 dist imports a bundled Vapor runtime chunk.
+// Route that import back to this app's Vue 3.6 runtime so server prerender can resolve it.
+export { vaporInteropPlugin as n, createVaporSSRApp as t } from "@vue/runtime-vapor";

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "catalog:css",
+    "@vue/runtime-vapor": "catalog:vue",
     "@vue/server-renderer": "catalog:vue",
     "@vuerend/core": "catalog:vuerend",
+    "srvx": "catalog:vuerend",
     "tailwindcss": "catalog:css",
     "vue": "catalog:vue"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,16 +51,20 @@ catalogs:
       specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
       version: 0.1.19
   vue:
-    '@vue/server-renderer':
-      specifier: 3.5.33
-      version: 3.5.33
-    vue:
-      specifier: 3.5.33
-      version: 3.5.33
+    '@vue/runtime-vapor':
+      specifier: 3.6.0-beta.10
+      version: 3.6.0-beta.10
   vuerend:
     '@vuerend/core':
-      specifier: 0.1.1-alpha.3
-      version: 0.1.1-alpha.3
+      specifier: 0.2.0
+      version: 0.2.0
+    srvx:
+      specifier: 0.11.14
+      version: 0.11.14
+
+overrides:
+  '@vue/server-renderer': 3.6.0-beta.10
+  vue: 3.6.0-beta.10
 
 importers:
 
@@ -69,18 +73,24 @@ importers:
       '@tailwindcss/vite':
         specifier: catalog:css
         version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
-      '@vue/server-renderer':
+      '@vue/runtime-vapor':
         specifier: catalog:vue
-        version: 3.5.33(vue@3.5.33(typescript@6.0.3))
+        version: 3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10)
+      '@vue/server-renderer':
+        specifier: 3.6.0-beta.10
+        version: 3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3))
       '@vuerend/core':
         specifier: catalog:vuerend
-        version: 0.1.1-alpha.3(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))
+        version: 0.2.0(@vue/runtime-vapor@3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10))(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))
+      srvx:
+        specifier: catalog:vuerend
+        version: 0.11.14
       tailwindcss:
         specifier: catalog:css
         version: 4.2.4
       vue:
-        specifier: catalog:vue
-        version: 3.5.33(typescript@6.0.3)
+        specifier: 3.6.0-beta.10
+        version: 3.6.0-beta.10(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: catalog:typescript
@@ -90,7 +100,7 @@ importers:
         version: 0.75.0(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
       '@vue/test-utils':
         specifier: catalog:test
-        version: 2.4.9(@vue/compiler-dom@3.5.33)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.9(@vue/compiler-dom@3.6.0-beta.10)(@vue/server-renderer@3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))
       oxlint:
         specifier: catalog:vize
         version: 1.62.0(oxlint-tsgolint@0.21.1)
@@ -857,9 +867,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -974,14 +981,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: ^3.0.0
+      vue: 3.6.0-beta.10
 
   '@vitejs/plugin-vue@6.0.6':
     resolution: {integrity: sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: ^3.2.25
+      vue: 3.6.0-beta.10
 
   '@vizejs/native-darwin-arm64@0.75.0':
     resolution: {integrity: sha512-xUB2B7CaWfnoYfe+9gn8MKWRGj82myVtnl62nTSwhV1MWtQ4JfniW+Ey294AlGRGlrP/ZaawyBMP85gx3tJvnA==}
@@ -1197,48 +1204,75 @@ packages:
   '@vue/compiler-core@3.5.33':
     resolution: {integrity: sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==}
 
+  '@vue/compiler-core@3.6.0-beta.10':
+    resolution: {integrity: sha512-hzkiI5eeO3YgCBlXRXM6HT8E7l2aE3FY4bBBdzHkXDEXy+13gDpztU/TdJQmr6OsER51tNponBOpqwkaZvpL7g==}
+
   '@vue/compiler-dom@3.5.33':
     resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
+
+  '@vue/compiler-dom@3.6.0-beta.10':
+    resolution: {integrity: sha512-syaKfkW2D4VFFndlNYweR/EqYWxpf1zCF2URtDcN8IJXV3jvsfOSZA+p8+kyNSbDtBEq8CAeulUXrRfORrM0mQ==}
 
   '@vue/compiler-sfc@3.5.33':
     resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
 
+  '@vue/compiler-sfc@3.6.0-beta.10':
+    resolution: {integrity: sha512-Pw6EkQB1a4wfh137rIgYwMwqc8v8JcsIwspzfGYG7a+St38gcnNGJFGVvfJh689EOLgfv1Z8was6ktrESfowwQ==}
+
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
 
-  '@vue/reactivity@3.5.33':
-    resolution: {integrity: sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==}
+  '@vue/compiler-ssr@3.6.0-beta.10':
+    resolution: {integrity: sha512-Pp5QQYgEhtv3C7irbeZP64gAWQjrsSnMlaNtBfgge/Cla/xE+HCQqE+8aJUndirtkmFutEA8CvHJ9K4FDHlOjQ==}
 
-  '@vue/runtime-core@3.5.33':
-    resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
+  '@vue/compiler-vapor@3.6.0-beta.10':
+    resolution: {integrity: sha512-9DqhmWnv06wefy/gBIix0bfphEDba0La96tt8jbNZb9+CbnbB0VyNCz70ynXyhbvrM5K9yhGcIqNfhkNhcepAQ==}
 
-  '@vue/runtime-dom@3.5.33':
-    resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
+  '@vue/reactivity@3.6.0-beta.10':
+    resolution: {integrity: sha512-YOdRI7G9SAI/Ic3dBUE1Mwzvb7J5h4Oqe0FijSi0y3mI4MWkMxNvWSSLkjqALSfAgixxjSRRfSR9Ln2jm53WeQ==}
 
-  '@vue/server-renderer@3.5.33':
-    resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
+  '@vue/runtime-core@3.6.0-beta.10':
+    resolution: {integrity: sha512-5cFbYbxtTm7H2Ch1qEdmUFySrPI/+aSmUJsJpMltG5gQJCuWN3kjVqeZp2AZB7pI3a2Jkq2NJC0gR++4eAw1xw==}
+
+  '@vue/runtime-dom@3.6.0-beta.10':
+    resolution: {integrity: sha512-w02s59Gq1NoZtSCpVKRWzk9No9BEq/eq9n1+KLre5WvYMIYjK0XBNN9cltZfE0/j5uZQlb87i4qR51YxFFbHog==}
+
+  '@vue/runtime-vapor@3.6.0-beta.10':
+    resolution: {integrity: sha512-MQOs7WughaIUFB6nL02kIHgjPpmiZeXnCLP303kihdfaS3vdsYzvc9u6cnTTtvfSGbyHq8F15rcz5QoRlF+zew==}
     peerDependencies:
-      vue: 3.5.33
+      '@vue/runtime-dom': 3.6.0-beta.10
+
+  '@vue/server-renderer@3.6.0-beta.10':
+    resolution: {integrity: sha512-K9bq8O1Hv2fHS0/aVkAxvvukkdy+U8W/nfFRQLcCCvQ92uLuMYsBp8+E3KZRdGaQbAAeuIf4GwJVCGXHTQEg9Q==}
+    peerDependencies:
+      vue: 3.6.0-beta.10
 
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
+
+  '@vue/shared@3.6.0-beta.10':
+    resolution: {integrity: sha512-13JUfIAd06F+IBnObE8mExDAMOknPIBjPBUN2JeemmuQwj5i20GduCLbHLVbxSkpFD0RGH4z2mOxUUdD+8M/Aw==}
 
   '@vue/test-utils@2.4.9':
     resolution: {integrity: sha512-YwgowiO1mPleZqpgAGfxvWu/A5A8nkLrbyH2SqiQRkyzCIaDzzo27/2uS/F1g7fRLvl8BUY0+Sr1eC+6+IHfrw==}
     peerDependencies:
       '@vue/compiler-dom': 3.x
-      '@vue/server-renderer': 3.x
-      vue: 3.x
+      '@vue/server-renderer': 3.6.0-beta.10
+      vue: 3.6.0-beta.10
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
 
-  '@vuerend/core@0.1.1-alpha.3':
-    resolution: {integrity: sha512-CULQtlH7MRnGu84ivII7yWt+/yYErw7/uZ+aQ6SL7xRuKyH3yYxpPlRL2QfZn3BvXO+PeXTn0DplS56BW1JcUA==}
+  '@vuerend/core@0.2.0':
+    resolution: {integrity: sha512-2Pyn+GeIJtGii2jgVrI/En/yaBja7NEUj+gK5L1QAGCisft407VmSUOO/zg7BwuZ2cR/BBZlh7Ud1Pjf6N+0zQ==}
     engines: {node: '>=24.0.0'}
     peerDependencies:
+      '@vue/runtime-vapor': ^3.6.0-beta.10
       vite: ^8.0.3
-      vue: ^3.5.31
+      vue: 3.6.0-beta.10
+    peerDependenciesMeta:
+      '@vue/runtime-vapor':
+        optional: true
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -1661,8 +1695,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  srvx@0.11.15:
-    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
+  srvx@0.11.14:
+    resolution: {integrity: sha512-mx+pKrWJCzo5m6uXqyB7n4VA81mpdFRroSWsVTQTYqCZE65hFJ+jtVIeyhtL2/kvtDMrHdbA0hWEUh/vu0+Viw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -1788,8 +1822,8 @@ packages:
   vue-component-type-helpers@3.2.7:
     resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
-  vue@3.5.33:
-    resolution: {integrity: sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==}
+  vue@3.6.0-beta.10:
+    resolution: {integrity: sha512-Bkc/Qd6FuPh6YbXkxDNtxqVQ3r6O3+hzSZfR9OtL5R74x3pIpjB/Qovqf6ysq0Fs6AIMFpClUOo8JfhhiVW2ow==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2340,8 +2374,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.4':
@@ -2428,23 +2460,23 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@rolldown/pluginutils': 1.0.0-rc.17
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.6.0-beta.10(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
       vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.6.0-beta.10(typescript@6.0.3)
 
   '@vizejs/native-darwin-arm64@0.75.0':
     optional: true
@@ -2600,10 +2632,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.6.0-beta.10':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.6.0-beta.10
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.33':
     dependencies:
       '@vue/compiler-core': 3.5.33
       '@vue/shared': 3.5.33
+
+  '@vue/compiler-dom@3.6.0-beta.10':
+    dependencies:
+      '@vue/compiler-core': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
 
   '@vue/compiler-sfc@3.5.33':
     dependencies:
@@ -2617,52 +2662,88 @@ snapshots:
       postcss: 8.5.10
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.6.0-beta.10':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.6.0-beta.10
+      '@vue/compiler-dom': 3.6.0-beta.10
+      '@vue/compiler-ssr': 3.6.0-beta.10
+      '@vue/compiler-vapor': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.10
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.33':
     dependencies:
       '@vue/compiler-dom': 3.5.33
       '@vue/shared': 3.5.33
 
-  '@vue/reactivity@3.5.33':
+  '@vue/compiler-ssr@3.6.0-beta.10':
     dependencies:
-      '@vue/shared': 3.5.33
+      '@vue/compiler-dom': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
 
-  '@vue/runtime-core@3.5.33':
+  '@vue/compiler-vapor@3.6.0-beta.10':
     dependencies:
-      '@vue/reactivity': 3.5.33
-      '@vue/shared': 3.5.33
+      '@babel/parser': 7.29.2
+      '@vue/compiler-dom': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
-  '@vue/runtime-dom@3.5.33':
+  '@vue/reactivity@3.6.0-beta.10':
     dependencies:
-      '@vue/reactivity': 3.5.33
-      '@vue/runtime-core': 3.5.33
-      '@vue/shared': 3.5.33
+      '@vue/shared': 3.6.0-beta.10
+
+  '@vue/runtime-core@3.6.0-beta.10':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
+
+  '@vue/runtime-dom@3.6.0-beta.10':
+    dependencies:
+      '@vue/reactivity': 3.6.0-beta.10
+      '@vue/runtime-core': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3))':
+  '@vue/runtime-vapor@3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10)':
     dependencies:
-      '@vue/compiler-ssr': 3.5.33
-      '@vue/shared': 3.5.33
-      vue: 3.5.33(typescript@6.0.3)
+      '@vue/reactivity': 3.6.0-beta.10
+      '@vue/runtime-dom': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
+
+  '@vue/server-renderer@3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.6.0-beta.10
+      '@vue/shared': 3.6.0-beta.10
+      vue: 3.6.0-beta.10(typescript@6.0.3)
 
   '@vue/shared@3.5.33': {}
 
-  '@vue/test-utils@2.4.9(@vue/compiler-dom@3.5.33)(@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))':
+  '@vue/shared@3.6.0-beta.10': {}
+
+  '@vue/test-utils@2.4.9(@vue/compiler-dom@3.6.0-beta.10)(@vue/server-renderer@3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-dom': 3.6.0-beta.10
       js-beautify: 1.15.4
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.6.0-beta.10(typescript@6.0.3)
       vue-component-type-helpers: 3.2.7
     optionalDependencies:
-      '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
+      '@vue/server-renderer': 3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3))
 
-  '@vuerend/core@0.1.1-alpha.3(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))':
+  '@vuerend/core@0.2.0(@vue/runtime-vapor@3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10))(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))':
     dependencies:
-      '@vitejs/plugin-vue': 6.0.6(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.5.33(typescript@6.0.3))
-      '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
-      srvx: 0.11.15
+      '@vitejs/plugin-vue': 6.0.6(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@6.0.3))
+      '@vue/server-renderer': 3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3))
+      srvx: 0.11.14
       vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.6.0-beta.10(typescript@6.0.3)
+    optionalDependencies:
+      '@vue/runtime-vapor': 3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -3077,7 +3158,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  srvx@0.11.15: {}
+  srvx@0.11.14: {}
 
   std-env@4.0.0: {}
 
@@ -3210,13 +3291,14 @@ snapshots:
 
   vue-component-type-helpers@3.2.7: {}
 
-  vue@3.5.33(typescript@6.0.3):
+  vue@3.6.0-beta.10(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.33
-      '@vue/compiler-sfc': 3.5.33
-      '@vue/runtime-dom': 3.5.33
-      '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@6.0.3))
-      '@vue/shared': 3.5.33
+      '@vue/compiler-dom': 3.6.0-beta.10
+      '@vue/compiler-sfc': 3.6.0-beta.10
+      '@vue/runtime-dom': 3.6.0-beta.10
+      '@vue/runtime-vapor': 3.6.0-beta.10(@vue/runtime-dom@3.6.0-beta.10)
+      '@vue/server-renderer': 3.6.0-beta.10(vue@3.6.0-beta.10(typescript@6.0.3))
+      '@vue/shared': 3.6.0-beta.10
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
   workerd: true
+
+overrides:
+  "@vue/server-renderer": 3.6.0-beta.10
+  vue: 3.6.0-beta.10
+
 catalogs:
   css:
     "@tailwindcss/vite": 4.2.4
@@ -19,10 +24,12 @@ catalogs:
   vite:
     vite: 8.0.10
   vue:
-    "@vue/server-renderer": 3.5.33
-    vue: 3.5.33
+    "@vue/runtime-vapor": 3.6.0-beta.10
+    "@vue/server-renderer": 3.6.0-beta.10
+    vue: 3.6.0-beta.10
   vuerend:
-    "@vuerend/core": 0.1.1-alpha.3
+    "@vuerend/core": 0.2.0
+    srvx: 0.11.14
   vize:
     "@vizejs/vite-plugin": 0.75.0
     oxlint: 1.62.0

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,6 +94,8 @@ const fmt = {
 
 export { fmt, lint };
 
+const vaporMode = process.env.VFJS_VAPOR !== "0";
+
 function staticHtmlPreview(): Plugin {
   return {
     name: "vfjs:static-html-preview",
@@ -205,7 +207,9 @@ export default defineConfig({
     vuerend({
       app: "./app/app.ts",
       islands: "./app/islands.ts",
+      vapor: vaporMode,
       vuePlugin: vize({
+        vapor: vaporMode,
         scanPatterns: ["app/**/*.vue"],
         ignorePatterns: ["node_modules/**", "dist/**", ".cache/**"],
       }),
@@ -222,6 +226,16 @@ export default defineConfig({
           import.meta.url,
         ),
       ),
+      "./runtime-vapor.esm-bundler-82sqnWQL.mjs": fileURLToPath(
+        new URL("./app/runtime/vuerend-vapor-runtime.ts", import.meta.url),
+      ),
+    },
+  },
+  environments: {
+    server: {
+      resolve: {
+        noExternal: ["@vuerend/core"],
+      },
     },
   },
   staged: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,12 +95,87 @@ const fmt = {
 export { fmt, lint };
 
 const vaporMode = process.env.VFJS_VAPOR !== "0";
+const vueServerRendererPath = fileURLToPath(
+  new URL(
+    "./node_modules/@vue/server-renderer/dist/server-renderer.esm-bundler.js",
+    import.meta.url,
+  ),
+);
+const vuerendVaporRuntimePath = fileURLToPath(
+  new URL("./app/runtime/vuerend-vapor-runtime.ts", import.meta.url),
+);
+
+function vuerendVaporRuntimeAlias(): Plugin {
+  return {
+    name: "vfjs:vuerend-vapor-runtime-alias",
+    enforce: "pre",
+    resolveId(id) {
+      if (
+        id === "./runtime-vapor.esm-bundler-82sqnWQL.mjs" ||
+        id.endsWith("/runtime-vapor.esm-bundler-82sqnWQL.mjs")
+      ) {
+        return vuerendVaporRuntimePath;
+      }
+    },
+  };
+}
 
 function staticHtmlPreview(): Plugin {
   return {
     name: "vfjs:static-html-preview",
     configurePreviewServer(server) {
-      const previewOutDir = resolve(server.config.root, server.config.build.outDir);
+      const configuredOutDir = resolve(server.config.root, server.config.build.outDir);
+      const clientOutDir = resolve(server.config.root, "dist/client");
+      const previewOutDir = existsSync(resolve(configuredOutDir, "index.html"))
+        ? configuredOutDir
+        : existsSync(resolve(clientOutDir, "index.html"))
+          ? clientOutDir
+          : configuredOutDir;
+
+      const contentTypes: Record<string, string> = {
+        ".css": "text/css;charset=utf-8",
+        ".html": "text/html;charset=utf-8",
+        ".ico": "image/x-icon",
+        ".js": "text/javascript;charset=utf-8",
+        ".json": "application/json;charset=utf-8",
+        ".png": "image/png",
+        ".svg": "image/svg+xml;charset=utf-8",
+        ".txt": "text/plain;charset=utf-8",
+        ".webp": "image/webp",
+        ".woff2": "font/woff2",
+      };
+
+      const isSafePath = (file: string) => {
+        const relativeFile = relative(previewOutDir, file);
+        return (
+          relativeFile !== "" && !relativeFile.startsWith("..") && !relativeFile.startsWith(sep)
+        );
+      };
+
+      const sendFile = (
+        request: IncomingMessage,
+        response: ServerResponse,
+        file: string,
+        statusCode: number,
+        contentType = contentTypes[extname(file)] ?? "application/octet-stream",
+      ) => {
+        const fileStat = statSync(file);
+        if (!fileStat.isFile()) {
+          return false;
+        }
+
+        response.statusCode = statusCode;
+        response.setHeader("Content-Type", contentType);
+        response.setHeader("Content-Length", fileStat.size);
+
+        if (request.method === "HEAD") {
+          response.end();
+        } else {
+          createReadStream(file).pipe(response);
+        }
+
+        return true;
+      };
 
       const sendHtml = (
         request: IncomingMessage,
@@ -108,22 +183,7 @@ function staticHtmlPreview(): Plugin {
         htmlFile: string,
         statusCode: number,
       ) => {
-        const htmlStat = statSync(htmlFile);
-        if (!htmlStat.isFile()) {
-          return false;
-        }
-
-        response.statusCode = statusCode;
-        response.setHeader("Content-Type", "text/html;charset=utf-8");
-        response.setHeader("Content-Length", htmlStat.size);
-
-        if (request.method === "HEAD") {
-          response.end();
-        } else {
-          createReadStream(htmlFile).pipe(response);
-        }
-
-        return true;
+        return sendFile(request, response, htmlFile, statusCode, "text/html;charset=utf-8");
       };
 
       server.middlewares.use((request, response, next) => {
@@ -139,6 +199,15 @@ function staticHtmlPreview(): Plugin {
 
         const url = new URL(request.url, "http://localhost");
         if (extname(url.pathname) !== "") {
+          const staticFile = resolve(previewOutDir, `.${url.pathname}`);
+          if (
+            isSafePath(staticFile) &&
+            existsSync(staticFile) &&
+            sendFile(request, response, staticFile, 200)
+          ) {
+            return;
+          }
+
           next();
           return;
         }
@@ -147,12 +216,9 @@ function staticHtmlPreview(): Plugin {
         const htmlPathname = pathname === "" ? "/index.html" : `${pathname}/index.html`;
         const htmlFile = resolve(previewOutDir, `.${htmlPathname}`);
         const notFoundFile = resolve(previewOutDir, "404.html");
-        const relativeHtmlFile = relative(previewOutDir, htmlFile);
 
         if (
-          relativeHtmlFile !== "" &&
-          !relativeHtmlFile.startsWith("..") &&
-          !relativeHtmlFile.startsWith(sep) &&
+          isSafePath(htmlFile) &&
           existsSync(htmlFile) &&
           sendHtml(request, response, htmlFile, 200)
         ) {
@@ -203,6 +269,7 @@ function cloudflarePages404(): Plugin {
 
 export default defineConfig({
   plugins: [
+    ...(vaporMode ? [vuerendVaporRuntimeAlias()] : []),
     tailwindcss(),
     vuerend({
       app: "./app/app.ts",
@@ -218,18 +285,32 @@ export default defineConfig({
     cloudflarePages404(),
   ],
   resolve: {
-    alias: {
+    alias: [
       // Vize SSR imports the package root; Vite's module runner needs the ESM build.
-      "@vue/server-renderer": fileURLToPath(
-        new URL(
-          "./node_modules/@vue/server-renderer/dist/server-renderer.esm-bundler.js",
-          import.meta.url,
-        ),
-      ),
-      "./runtime-vapor.esm-bundler-82sqnWQL.mjs": fileURLToPath(
-        new URL("./app/runtime/vuerend-vapor-runtime.ts", import.meta.url),
-      ),
-    },
+      {
+        find: "@vue/server-renderer",
+        replacement: vueServerRendererPath,
+      },
+      ...(vaporMode
+        ? [
+            {
+              find: "./runtime-vapor.esm-bundler-82sqnWQL.mjs",
+              replacement: vuerendVaporRuntimePath,
+            },
+          ]
+        : []),
+    ],
+  },
+  ...(vaporMode
+    ? {
+        optimizeDeps: {
+          exclude: ["@vuerend/core", "@vuerend/core/client/vapor-hydrate"],
+        },
+      }
+    : {}),
+  build: {
+    modulePreload: false,
+    target: "esnext",
   },
   environments: {
     server: {


### PR DESCRIPTION
## Summary
- Upgrade Vue to 3.6.0 beta and Vuerend to 0.2.0.
- Enable Vuerend/Vize Vapor mode by default.
- Mark island subtree SFCs with `<script setup vapor>` and use Vue 3 reactive props destructure instead of `toRefs`.
- Add a runtime alias shim for the published Vuerend 0.2.0 Vapor runtime chunk.
- Mount Vapor islands over SSR HTML on idle while Vapor SSR hydration is still unstable.
- Keep static preview working with `dist/client` output and disable module preload for smaller critical loading.

## Production Benchmark

Compared against `origin/main` (`b8eddf7`) using `vp build` for both branches.
Browser timings use local `vp preview --outDir dist/client`, Chromium, 7 cold runs, median values, no service worker.

| Metric | main | Vapor branch | Delta |
| --- | ---: | ---: | ---: |
| Client JS assets total | 100,704 B raw / 38,207 B gzip | 98,617 B raw / 36,128 B gzip | -2,087 B raw / -2,079 B gzip |
| Home loaded JS | 93,975 B raw / 35,301 B gzip | 89,639 B raw / 32,268 B gzip | -4,336 B raw / -3,033 B gzip |
| Vue runtime chunk | 63,722 B raw / 24,954 B gzip | 54,122 B raw / 20,208 B gzip | -9,600 B raw / -4,746 B gzip |
| FCP median | 188.0 ms | 180.0 ms | -8.0 ms |
| DOMContentLoaded median | 183.9 ms | 173.9 ms | -10.0 ms |
| Last JS response end median | 186.7 ms | 186.2 ms | -0.5 ms |
| loadEventEnd median | 303.7 ms | 447.5 ms | +143.8 ms |

## Notes
- The runtime chunk is smaller with Vapor, but the SFC chunks are larger, so total JS improvement is modest.
- SSR HTML is visible before island mount, and local load timing is noisy; `loadEventEnd` did not improve in this run even though Home loaded JS gzip decreased by ~3.0 kB.
- Browser smoke on the Vapor build reports no console warnings/errors, and search, view switching, and row expansion work.
- Server build still logs Vize warnings that SFC Vapor SSR is not supported yet and falls back to standard SSR output; this is expected for now.

## Verification
- `vp fmt . --check`
- `vp lint .`
- `vp run typecheck`
- `vp test run`
- `vp build`
