### PR TITLE
fix: exclude Musea art files from vize lint

### DIFF
--- a/config/vite/tooling.ts
+++ b/config/vite/tooling.ts
@@ -57,7 +57,7 @@ export const fmt = {
 export const runTasks = {
   lint: {
     command:
-      'vp lint . --format stylish --max-warnings 0 && vize lint --help-level short --max-warnings 0 "src/**/*.vue"',
+      "vp lint . --format stylish --max-warnings 0 && vize lint --help-level short --max-warnings 0 $(find src -name '*.vue' ! -name '*.art.vue')",
   },
   check: {
     command: "vp run lint && vp run format:check && vp run typecheck",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Exclude `*.art.vue` from the `vize lint` step in `vp run lint`
- Uses the same `find` pattern already used by `format` and `format:check`

## Context

Vize 0.315.1 introduces `vue/warn-custom-block` warnings for Musea `<art>` custom blocks. With CI configured as `--max-warnings 0`, Renovate PR #804 fails lint even though the app code is unchanged.

## Verification

- `vp run lint` passes on main (Vize 0.291.0)
- `vp run lint` passes with Vize 0.315.1 after this change (15 Vue files linted, 11 art files skipped)

## Related

- Fixes lint failure in #804 once merged and Renovate rebases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f737bfc-0dba-4a20-9004-779a981372a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f737bfc-0dba-4a20-9004-779a981372a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

