### PR TITLE
chore: set up Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,14 @@ Browser Mode の test job では、テスト前に `vp exec playwright install -
 - Vite Plus 設定の不整合: `vp config` を再実行する。
 - Browser Mode のブラウザ不足: `vp exec playwright install chromium` を実行する。Linux CI では `--with-deps` も付ける。
 - キャッシュ問題: Vite や生成物のキャッシュが怪しい場合は開発サーバを再起動する。
+
+## Cursor Cloud specific instructions
+
+このセクションは、依存インストール済みの Cloud Agent VM で作業する将来のエージェント向けの補足です。標準コマンドは上記の表（README / AGENTS）を参照してください。ここには非自明な注意点のみを記載します。
+
+- `vp` の PATH: `vp` は `~/.vite-plus` にインストールされ、対話シェルでは `~/.bashrc` 経由で読み込まれます。非対話シェル（スクリプトや `tmux send-keys` など）では `vp` が PATH に無いことがあるので、先に `. "$HOME/.vite-plus/env"` を読み込んでから `vp` を実行してください。
+- 開発サーバ: `vp dev` は `http://localhost:5173/`（Vite のデフォルトポート）で起動します。`server.port` の明示設定はありません。長時間走らせる場合は tmux セッションで起動してください。
+- テスト: `vp test run` は Vitest の Browser Mode（Playwright / Chromium）で動きます。Chromium は環境更新スクリプト（`vp exec playwright install chromium`）で導入済みです。ブラウザが見つからないエラーが出たら同コマンドを再実行してください。
+- Node: 既定の環境 Node（v22 系 LTS）で lint / typecheck / test / build / dev すべて動作します。CI は Node 24 です。
+- クライアント遷移の描画: dev サーバでスピーカー詳細（`/speakers/:name`）へクライアント遷移する際、一瞬ローディング表示（白いキューブ）を挟んでから描画されます。最終描画は正常です（`curl` でも各ルートは 200 を返します）。
+- ビルド確認: `vp build` は SSG で全ルート（現在 156 ルート）を `dist/client` に生成します。生成物の確認は `vp preview --outDir dist/client`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this Vue Fes Japan Speakers archive site (vuerend / Vite Plus / Vize) in the Cursor Cloud Agent VM, and captures durable startup notes for future agents.

This PR only adds documentation. The environment itself (dependencies, Playwright Chromium, update script) is configured via the Cloud Agent environment/update-script mechanism, not committed code.

## What was set up

- Installed the Vite Plus CLI (`vp`) via `curl -fsSL https://vite.plus | bash`.
- Installed project dependencies with `vp install` (pnpm 11.18.0 catalogs).
- Installed Playwright Chromium for Vitest Browser Mode.
- Verified everything works on the default environment Node (v22 LTS); CI uses Node 24.

## Verified commands

| Purpose | Command | Result |
| --- | --- | --- |
| Lint | `vp run lint` | No problems in 15 files |
| Format check | `vp run format:check` | All files correctly formatted |
| Type check | `vp run typecheck` | 118 files, no type errors |
| Test | `vp test run` | 7 files, 22 tests passed (browser mode) |
| Build | `vp build` | SSG, 156 routes prerendered to `dist/client` |
| Dev server | `vp dev` | Serves at `http://localhost:5173/` |

## Hello-world (end-to-end) verification

Ran the dev server and exercised the site's core functionality in a browser: keyword search, year filtering, switching to the Directory (スピーカー) view, and navigating to a speaker detail page (`/speakers/Evan You`), which renders the full profile with all 8 appearances.

[vuefes_speakers_search_filter_and_detail_demo.mp4](https://cursor.com/agents/bc-f524de78-741c-4904-9df2-8286e4b53ce8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvuefes_speakers_search_filter_and_detail_demo.mp4)

[Speaker detail page for Evan You](https://cursor.com/agents/bc-f524de78-741c-4904-9df2-8286e4b53ce8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeaker_detail_evan_you.webp)

## Changes

- `AGENTS.md`: added a `## Cursor Cloud specific instructions` section with non-obvious startup caveats (how to get `vp` on PATH in non-interactive shells, dev server port, browser-mode test browser, Node version, transient client-navigation loading frame).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f524de78-741c-4904-9df2-8286e4b53ce8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f524de78-741c-4904-9df2-8286e4b53ce8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

