### PR TITLE
feat: Vue Fes Japan 2026 スピーカーデータを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [RubyKaigiの2006年から2024年までの登壇者一覧を見れるWebページを作った - Eggshell](https://imaizumimr.hatenablog.com/entry/2024/08/20/204241)
   - [ima1zumi/RubyKaigi-speakers](https://github.com/ima1zumi/RubyKaigi-speakers)
 - [Vue.js Japan User Group](https://github.com/vuejs-jp)
+  - [Vue Fes Japan 2026](https://vuefes.jp/2026/)
   - [Vue Fes Japan 2025](https://vuefes.jp/2025/)
   - [Vue Fes Japan 2024](https://vuefes.jp/2024/)
   - [Vue Fes Japan 2023](https://vuefes.jp/2023/)

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -10,14 +10,6 @@ describe("speaker data accessors", () => {
     expect(speakers.every((speaker) => Array.isArray(speaker.name))).toBe(true);
   });
 
-  it("2026年データを取得できる", () => {
-    const speakers = getSpeakersByYear("2026");
-
-    expect(speakers.length).toBeGreaterThan(0);
-    expect(speakers.every((speaker) => Array.isArray(speaker.name))).toBe(true);
-    expect(speakers.every((speaker) => speaker.url.includes("/2026/"))).toBe(true);
-  });
-
   it("全件データにyearを付与する", () => {
     const speakers = getAllSpeakersWithYear();
 

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -23,6 +23,5 @@ describe("speaker data accessors", () => {
 
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => YEARS.includes(speaker.year))).toBe(true);
-    expect(YEARS).toContain("2026");
   });
 });

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -10,10 +10,19 @@ describe("speaker data accessors", () => {
     expect(speakers.every((speaker) => Array.isArray(speaker.name))).toBe(true);
   });
 
+  it("2026年データを取得できる", () => {
+    const speakers = getSpeakersByYear("2026");
+
+    expect(speakers.length).toBeGreaterThan(0);
+    expect(speakers.every((speaker) => Array.isArray(speaker.name))).toBe(true);
+    expect(speakers.every((speaker) => speaker.url.includes("/2026/"))).toBe(true);
+  });
+
   it("全件データにyearを付与する", () => {
     const speakers = getAllSpeakersWithYear();
 
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => YEARS.includes(speaker.year))).toBe(true);
+    expect(YEARS).toContain("2026");
   });
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -6,6 +6,7 @@ import { speakers2022 } from "./speakers-2022";
 import { speakers2023 } from "./speakers-2023";
 import { speakers2024 } from "./speakers-2024";
 import { speakers2025 } from "./speakers-2025";
+import { speakers2026 } from "./speakers-2026";
 
 // Speakers organized by year
 const speakersByYear = {
@@ -15,6 +16,7 @@ const speakersByYear = {
   2023: speakers2023,
   2024: speakers2024,
   2025: speakers2025,
+  2026: speakers2026,
 } satisfies Record<AcceptedYear, SpeakerInfo[]>;
 
 // Helper function to get speakers by year

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -77,7 +77,8 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["平沼 真吾"],
-    title: "Vue で書く 空間コンピューティング、TresJS と WebXR を使ったXR デバイスのフロントエンド開発",
+    title:
+      "Vue で書く 空間コンピューティング、TresJS と WebXR を使ったXR デバイスのフロントエンド開発",
     url: "https://vuefes.jp/2026/speaker/hiranuma",
   },
   {

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -1,0 +1,173 @@
+import type { SpeakerInfo } from "../../types";
+
+export const speakers2026: SpeakerInfo[] = [
+  {
+    name: ["Evan You"],
+    title: "キーノート",
+    url: "https://vuefes.jp/2026/speaker/yyx990803",
+  },
+  {
+    name: ["Eduardo San Martin Morote (Posva)"],
+    url: "https://vuefes.jp/2026/speaker/posva",
+  },
+  {
+    name: ["Pooya Parsa"],
+    url: "https://vuefes.jp/2026/speaker/pi0",
+  },
+  {
+    name: ["Charles Wang"],
+    title: "Vite-plus (仮)",
+    url: "https://vuefes.jp/2026/speaker/wan9chi",
+  },
+  {
+    name: ["ubugeeei"],
+    title: "The Vue Toolchain, Reimagined",
+    url: "https://vuefes.jp/2026/speaker/ubugeeei",
+  },
+  {
+    name: ["中野 美咲"],
+    url: "https://vuefes.jp/2026/speaker/mnmxmx",
+  },
+  {
+    name: ["Leo Kettmeir"],
+    url: "https://vuefes.jp/2026/speaker/crowlKats",
+  },
+  {
+    name: ["Alistair Smith"],
+    url: "https://vuefes.jp/2026/speaker/alii",
+  },
+  {
+    name: ["Kongkeit Khunpanitchot (aka saltyaom)"],
+    url: "https://vuefes.jp/2026/speaker/SaltyAom",
+  },
+  {
+    name: ["Yusuke Wada"],
+    url: "https://vuefes.jp/2026/speaker/yusukebe",
+  },
+  {
+    name: ["古川 陽介"],
+    url: "https://vuefes.jp/2026/speaker/yosuke-furukawa",
+  },
+  {
+    name: ["Naoki Haba"],
+    title: "Vite+への貢献と、Team Memberになって見えてきた風景",
+    url: "https://vuefes.jp/2026/speaker/naokihaba",
+  },
+  {
+    name: ["Marc Backes"],
+    title: "The Backend is Reactive: ブラウザの枠を超える Vue",
+    url: "https://vuefes.jp/2026/speaker/themarcba",
+  },
+  {
+    name: ["Alvarosabu"],
+    title: "Vue Fes Japan 2025 の Web サイトを TresJS と TSL（WebGPU）で再現する",
+    url: "https://vuefes.jp/2026/speaker/alvarosabu",
+  },
+  {
+    name: ["永井優斗"],
+    nameRuby: ["ながい ゆうと"],
+    nameEn: ["Yuto NAGAI"],
+    title: "Vue.jsのGitHubから学ぶ意思決定",
+    url: "https://vuefes.jp/2026/speaker/yut0naga1",
+  },
+  {
+    name: ["Yutaro Koizumi"],
+    title: "Nuxt ContentからOxContentへ、1000ページ超のブログ基盤刷新への挑戦",
+    url: "https://vuefes.jp/2026/speaker/ykoizumi0903",
+  },
+  {
+    name: ["平沼 真吾"],
+    title: "Vue で書く 空間コンピューティング、TresJS と WebXR を使ったXR デバイスのフロントエンド開発",
+    url: "https://vuefes.jp/2026/speaker/hiranuma",
+  },
+  {
+    name: ["ushironoko"],
+    title: "型なし、テストなし、1万行のドメインロジックがあるVuexをPiniaへ移行する",
+    url: "https://vuefes.jp/2026/speaker/ushironoko",
+  },
+  {
+    name: ["辻佳佑"],
+    title: "決定的なフロントエンドアーキテクチャがいい",
+    url: "https://vuefes.jp/2026/speaker/t0daaay",
+  },
+  {
+    name: ["jp-knj"],
+    title: "AstroとRustで考えるフロントエンドツールチェーンの今",
+    url: "https://vuefes.jp/2026/speaker/jp-knj",
+  },
+  {
+    name: ["池田 泰延"],
+    title: "JSがこんなに減る！ HTML・CSS最新技術2026",
+    url: "https://vuefes.jp/2026/speaker/ics-ikeda",
+  },
+  {
+    name: ["Katashin"],
+    title: "なぜその UI アニメーションは気持ちいいのか？",
+    url: "https://vuefes.jp/2026/speaker/ktsn",
+  },
+  {
+    name: ["やまのく"],
+    title: "Vue SFCから見直す正しいHTMLの守り方",
+    url: "https://vuefes.jp/2026/speaker/yamanoku",
+  },
+  {
+    name: ["aoshi"],
+    title: "TanStack Query VueとPinia Coladaから学ぶ非同期状態の型設計",
+    url: "https://vuefes.jp/2026/speaker/is78-dev",
+  },
+  {
+    name: ["Hal"],
+    title: "Vue.jsで作る空間解析アプリとCapacitorプラグインのData Bridge",
+    url: "https://vuefes.jp/2026/speaker/Hal-Spidernight",
+  },
+  {
+    name: ["福田繁之"],
+    title: "Vapor Modeでアクセシビリティは壊れないか検証した話",
+    url: "https://vuefes.jp/2026/speaker/Shigeyuki-fukuda",
+  },
+  {
+    name: ["Hasuto"],
+    title: "あなたの await、OS まで届いてる？ strace で覗く JavaScript の非同期",
+    url: "https://vuefes.jp/2026/speaker/HasutoSasaki",
+  },
+  {
+    name: ["northprint"],
+    title: "v-ifとフラグ地獄からの脱出 — Pinia で作る画面遷移ステートマシン",
+    url: "https://vuefes.jp/2026/speaker/northprint",
+  },
+  {
+    name: ["ぶりお"],
+    title: "Vite+を爆速で社内のデザインシステムに導入してみた",
+    url: "https://vuefes.jp/2026/speaker/Koutaro-Hanabusa",
+  },
+  {
+    name: ["hakshu"],
+    title: "Vite+のちょっとした改善から学ぶ、OSSコントリビューションの始め方",
+    url: "https://vuefes.jp/2026/speaker/hakshu25",
+  },
+  {
+    name: ["ノワン"],
+    title: "外国人エンジニアがVueプロトタイプで仕様を合わせている話",
+    url: "https://vuefes.jp/2026/speaker/Eluwing",
+  },
+  {
+    name: ["にー兄さん"],
+    title: "Web3Dライブラリを作ってVue Custom Rendererの仕組みを理解しよう",
+    url: "https://vuefes.jp/2026/speaker/drumath2237",
+  },
+  {
+    name: ["ryuhei373"],
+    title: "結局Nuxt Layersって何ができて何が嬉しいの？",
+    url: "https://vuefes.jp/2026/speaker/ryuhei373",
+  },
+  {
+    name: ["kouki.miura"],
+    title: "SFCで実現する病院・医療システムの動的組み立て式UI",
+    url: "https://vuefes.jp/2026/speaker/koki_m",
+  },
+  {
+    name: ["キナ"],
+    title: "便利で危険なDeep Reactivityとの付き合い方",
+    url: "https://vuefes.jp/2026/speaker/CrafterKina",
+  },
+];

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -7,7 +7,7 @@ export const speakers2026: SpeakerInfo[] = [
     url: "https://vuefes.jp/2026/speaker/yyx990803",
   },
   {
-    name: ["Eduardo San Martin Morote (Posva)"],
+    name: ["Eduardo San Martin Morote"],
     url: "https://vuefes.jp/2026/speaker/posva",
   },
   {

--- a/src/utils/years.test.ts
+++ b/src/utils/years.test.ts
@@ -4,7 +4,7 @@ import type { AcceptedYear } from "../../types";
 
 describe("isValidYear", () => {
   describe("有効な年", () => {
-    it.each([["2018"], ["2019"], ["2022"], ["2023"], ["2024"], ["2025"]])(
+    it.each([["2018"], ["2019"], ["2022"], ["2023"], ["2024"], ["2025"], ["2026"]])(
       "%sの場合trueを返す",
       (year) => {
         expect(isValidYear(year)).toBe(true);

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,7 +9,7 @@ export type SpeakerInfo = {
   format?: SessionFormat;
 };
 
-export const YEARS = ["2018", "2019", "2022", "2023", "2024", "2025"] as const;
+export const YEARS = ["2018", "2019", "2022", "2023", "2024", "2025", "2026"] as const;
 export type AcceptedYear = (typeof YEARS)[number];
 
 export type SpeakerWithYear = SpeakerInfo & { year: AcceptedYear };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- [Vue Fes Japan 2026 スピーカーページ](https://vuefes.jp/2026/speaker) から発表済みの登壇者 35 名を `src/data/speakers-2026.ts` に追加
- `YEARS` / `speakersByYear` に `2026` を登録し、一覧・年別・スピーカー詳細ルートで表示できるようにした
- 発表タイトル未公開の登壇者は `title` を省略（UI 側の TBD 表示に委譲）
- README の参考リンクと関連テストを更新

## Notes
- パネルディスカッション / スポンサーセッションは公式側が TBD のため今回は未収録
- タイトルが「TBD」のみの登壇者（Posva, 中野美咲など）も `title` 未設定として扱っています

## Test plan
- [x] `vp run lint`
- [x] `vp run format:check`
- [x] `vp run typecheck`
- [x] `vp test run`（24 tests passed）
- [x] `/` と `/2026` で 2026 年が表示されること
- [x] `/speakers/:name` で 2026 のトークが紐づくこと
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f720c14e-6384-4b8b-bd70-8371ec8b324d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f720c14e-6384-4b8b-bd70-8371ec8b324d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

