### PR TITLE
fix: unify speaker name katashin → Katashin

### DIFF
--- a/src/data/speakers-2018.ts
+++ b/src/data/speakers-2018.ts
@@ -17,7 +17,7 @@ export const speakers2018: SpeakerInfo[] = [
     url: "https://vuefes.jp/2018/speakers/takanorip/",
   },
   {
-    name: ["katashin"],
+    name: ["Katashin"],
     title: "Vue Designer: デザインと実装の統合",
     url: "https://vuefes.jp/2018/speakers/ktsn/",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 2018 のデータで `katashin`、2026 で `Katashin` と表記が分かれており、DirectoryView のスピーカー集約で別人扱いになっていました
- `src/data/speakers-2018.ts` の表記を `Katashin` に統一しました

## Test plan
- [x] `vp run lint`
- [x] `vp run format:check`
- [x] `vp run typecheck`
- [x] `vp test run`
- [ ] `/` の DirectoryView で Katashin が 2018 / 2026 の両方のトークを持つ1件として表示されることを確認
- [ ] `/speakers/Katashin` で両年の発表が一覧されることを確認

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a56205f1-4a2c-4cf3-bdd9-b18dbd1d3087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a56205f1-4a2c-4cf3-bdd9-b18dbd1d3087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

