### PR TITLE
fix: Directory タブの登壇回数バッジから半角スペースを除去

### DIFF
--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -215,7 +215,7 @@ function updateSelectedYear(value: AcceptedYear | "all") {
                   class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px] after:content-[attr(data-count)]"
                   :aria-label="t.appearance_count(rec.talks.length)"
                   :data-count="`×${rec.talks.length}`"
-                />
+                ></span>
               </span>
               <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
               <span

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -209,16 +209,13 @@ function updateSelectedYear(value: AcceptedYear | "all") {
                 <template v-else>
                   {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
                 </template>
-                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示） -->
+                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示。formatter の改行空白を避けるため data-count で描画） -->
                 <span
                   v-if="rec.talks.length > 1"
-                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
+                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px] after:content-[attr(data-count)]"
                   :aria-label="t.appearance_count(rec.talks.length)"
-                >
-                  <span>
-                    ×{{ rec.talks.length }}
-                  </span>
-                </span>
+                  :data-count="`×${rec.talks.length}`"
+                />
               </span>
               <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
               <span


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- TOP ページの Speaker（Directory）タブで、登壇回数バッジが ` ×9`（先頭に半角スペース）と描画されていた問題を修正しました
- 原因はテンプレートのインデント空白が Vue の whitespace condense により半角スペースになっていたことです
- `×N` を `data-count` + CSS `after:content-[attr(data-count)]` で描画し、フォーマッタが改行を入れても空白が入らないようにしました
- 非 void 要素への自己閉じ (`<span />`) は Vize typecheck で弾かれるため、明示的な `></span>` に変更しました

[Directory badges without space](https://cursor.com/agents/bc-24b15ecb-5c0f-4952-9b99-637ff1b7acae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdirectory-tab-badges.webp)

## Test plan
- [x] TOP ページで Speaker（Directory）タブを開き、バッジが `×9` / `×6`（スペースなし）と表示されること
- [x] `vp run lint` / `vp run format:check` / `vp run typecheck` / `vp test run` が通ること

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24b15ecb-5c0f-4952-9b99-637ff1b7acae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24b15ecb-5c0f-4952-9b99-637ff1b7acae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

