### PR TITLE
fix: unify speaker name ushironoko → うしろのこ

### DIFF
--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { YEARS } from "../../types";
+import { getSpeakerNames, getSpeakerTalks } from "../composables/speaker";
 import { getAllSpeakersWithYear, getSpeakersByYear } from "./index";
 
 describe("speaker data accessors", () => {
@@ -15,5 +16,14 @@ describe("speaker data accessors", () => {
 
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => YEARS.includes(speaker.year))).toBe(true);
+  });
+
+  it("うしろのこは ushironoko と同一人物として集約される", () => {
+    const talks = getSpeakerTalks("うしろのこ");
+    const years = talks.map((talk) => talk.year);
+
+    expect(years).toEqual(expect.arrayContaining(["2022", "2023", "2026"]));
+    expect(getSpeakerNames()).not.toContain("ushironoko");
+    expect(getSpeakerTalks("ushironoko")).toEqual([]);
   });
 });

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
 import { YEARS } from "../../types";
-import { getSpeakerNames, getSpeakerTalks } from "../composables/speaker";
 import { getAllSpeakersWithYear, getSpeakersByYear } from "./index";
 
 describe("speaker data accessors", () => {
@@ -16,14 +15,5 @@ describe("speaker data accessors", () => {
 
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => YEARS.includes(speaker.year))).toBe(true);
-  });
-
-  it("うしろのこは ushironoko と同一人物として集約される", () => {
-    const talks = getSpeakerTalks("うしろのこ");
-    const years = talks.map((talk) => talk.year);
-
-    expect(years).toEqual(expect.arrayContaining(["2022", "2023", "2026"]));
-    expect(getSpeakerNames()).not.toContain("ushironoko");
-    expect(getSpeakerTalks("ushironoko")).toEqual([]);
   });
 });

--- a/src/data/speakers-2022.ts
+++ b/src/data/speakers-2022.ts
@@ -126,6 +126,7 @@ export const speakers2022: SpeakerInfo[] = [
   },
   {
     name: ["miyaoka", "うしろのこ", "takanorip", "やまのく", "kazupon"],
+    nameEn: ["miyaoka", "ushironoko", "takanorip", "やまのく", "kazupon"],
     title: "なるほどVueコンポーネント",
     url: "https://vuefes.jp/2022/#naruhodo-vue-component",
     format: "panel",

--- a/src/data/speakers-2023.ts
+++ b/src/data/speakers-2023.ts
@@ -154,6 +154,7 @@ export const speakers2023: SpeakerInfo[] = [
   },
   {
     name: ["takanorip", "miyaoka", "wattanx", "やまのく", "うしろのこ", "kazupon"],
+    nameEn: ["takanorip", "miyaoka", "wattanx", "やまのく", "ushironoko", "kazupon"],
     title: "なぜVueを選んだのか？",
     url: "https://vuefes.jp/2023/#events-panel",
     format: "panel",

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -82,7 +82,7 @@ export const speakers2026: SpeakerInfo[] = [
     url: "https://vuefes.jp/2026/speaker/hiranuma",
   },
   {
-    name: ["ushironoko"],
+    name: ["うしろのこ"],
     title: "型なし、テストなし、1万行のドメインロジックがあるVuexをPiniaへ移行する",
     url: "https://vuefes.jp/2026/speaker/ushironoko",
   },

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -83,6 +83,7 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["うしろのこ"],
+    nameEn: ["ushironoko"],
     title: "型なし、テストなし、1万行のドメインロジックがあるVuexをPiniaへ移行する",
     url: "https://vuefes.jp/2026/speaker/ushironoko",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 2022/2023 のデータでは `うしろのこ`、2026 では `ushironoko` と表記が分かれており、DirectoryView のスピーカー集約で別人扱いになっていました
- `src/data/speakers-2026.ts` の表記を `うしろのこ` に統一しました（公式スピーカーページ URL の slug はそのまま）
- 英語表記として `nameEn: ["ushironoko"]` を 2022 / 2023 / 2026 の各エントリに追加しました

## Test plan
- [x] `vp run lint`
- [x] `vp run format:check`
- [x] `vp run typecheck`
- [x] `vp test run`
- [ ] `/` の DirectoryView で「うしろのこ」が 2022 / 2023 / 2026 のトークを持つ1件として表示されることを確認
- [ ] `/speakers/うしろのこ` で各年の発表が一覧されることを確認
- [ ] 英語表示で `ushironoko` と表示されることを確認

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f5ffba-2a14-4f74-b738-fe845529773b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f5ffba-2a14-4f74-b738-fe845529773b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

