### PR TITLE
fix(a11y): Major アクセシビリティ課題を修正 (#836)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -26,7 +26,7 @@
     --rule-softer: rgba(232, 228, 220, 0.07);
     --ink: #e8e4dc;
     --ink-2: #b4b0a8;
-    --ink-3: #7a7a72;
+    --ink-3: #888880;
     --accent: #2ed9a8;
     --accent-ink: #0d2820;
   }
@@ -40,7 +40,7 @@
   --rule-softer: rgba(232, 228, 220, 0.07);
   --ink: #e8e4dc;
   --ink-2: #b4b0a8;
-  --ink-3: #7a7a72;
+  --ink-3: #888880;
   --accent: #2ed9a8;
   --accent-ink: #0d2820;
 }
@@ -91,6 +91,49 @@ body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-feature-settings: "ss01", "cv02", "cv11";
+}
+
+html {
+  scroll-padding-top: 72px;
+}
+
+.skip-links {
+  position: absolute;
+  z-index: 30;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  top: 8px;
+  left: var(--pad-x);
+}
+
+.skip-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  padding: 8px 12px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-decoration: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -5,7 +5,11 @@ const { t } = useVfjsI18n();
 </script>
 
 <template>
-  <footer class="border-t border-rule flex flex-wrap gap-x-6 gap-y-2 items-baseline justify-between px-pad-x py-5 text-[12px] font-mono">
+  <footer
+    id="site-footer"
+    class="border-t border-rule flex flex-wrap gap-x-6 gap-y-2 items-baseline justify-between px-pad-x py-5 text-[12px] font-mono"
+    tabindex="-1"
+  >
     <!-- トップページへ戻るリンク -->
     <div>
       <a class="text-inherit underline hover:no-underline hover:text-ink" href="/">

--- a/src/components/AppHeader.test.ts
+++ b/src/components/AppHeader.test.ts
@@ -19,6 +19,15 @@ describe("AppHeader", () => {
     expect(html).not.toMatch(/<option(?=[^>]*\bvalue="light")(?=[^>]*\bselected)[^>]*>/);
   });
 
+  it("本文とフッターへのスキップリンクを先頭に置く", async () => {
+    const html = await renderToString(createSSRApp(AppHeader));
+
+    expect(html).toContain('href="#main"');
+    expect(html).toContain('href="#site-footer"');
+    expect(html).toContain("本文へ");
+    expect(html).toContain("フッターへ");
+  });
+
   it("保存済みの配色設定をマウント後に反映する", async () => {
     localStorage.setItem(STORAGE_KEY, "light");
 

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AppLogoMark from "./AppLogoMark.vue";
+import SkipLinks from "./SkipLinks.vue";
 import { useColorScheme } from "../composables/useColorScheme";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
@@ -21,14 +22,11 @@ function setEnglish() {
 
 <template>
   <!-- 本文・フッターへジャンプするスキップリンク（フォーカス時のみ表示） -->
-  <nav class="skip-links" :aria-label="t.skip_links">
-    <a class="skip-link" href="#main">
-      {{ t.skip_to_main }}
-    </a>
+  <SkipLinks>
     <a class="skip-link" href="#site-footer">
       {{ t.skip_to_footer }}
     </a>
-  </nav>
+  </SkipLinks>
   <!-- サイト全体のヘッダー（スクロール時にページ上部へ固定） -->
   <header class="border-b border-rule bg-paper sticky top-0 z-20 [backdrop-filter:saturate(1.1)]">
     <div class="flex flex-wrap justify-between items-center gap-2 py-[14px] px-pad-x">

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -20,6 +20,15 @@ function setEnglish() {
 </script>
 
 <template>
+  <!-- 本文・フッターへジャンプするスキップリンク（フォーカス時のみ表示） -->
+  <nav class="skip-links" :aria-label="t.skip_links">
+    <a class="skip-link" href="#main">
+      {{ t.skip_to_main }}
+    </a>
+    <a class="skip-link" href="#site-footer">
+      {{ t.skip_to_footer }}
+    </a>
+  </nav>
   <!-- サイト全体のヘッダー（スクロール時にページ上部へ固定） -->
   <header class="border-b border-rule bg-paper sticky top-0 z-20 [backdrop-filter:saturate(1.1)]">
     <div class="flex flex-wrap justify-between items-center gap-2 py-[14px] px-pad-x">

--- a/src/components/ChronicleView.test.ts
+++ b/src/components/ChronicleView.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakers } from "../../musea/sample-data";
+import ChronicleView from "./ChronicleView.vue";
+
+describe("ChronicleView", () => {
+  it("各年を見出しにして目次とライブリージョンを置く", () => {
+    const wrapper = mount(ChronicleView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        query: "",
+        selectedSpeaker: "all",
+        selectedYear: "all",
+      },
+    });
+
+    const headings = wrapper.findAll("h2");
+    expect(headings.map((heading) => heading.text())).toEqual(
+      expect.arrayContaining(["2018全 1 発表", "2025全 2 発表"]),
+    );
+    expect(wrapper.find("main#main").exists()).toBe(true);
+    expect(wrapper.find('nav[aria-label="年度"]').exists()).toBe(true);
+    expect(wrapper.find('a[href="#year-2018"]').exists()).toBe(true);
+
+    const status = wrapper.find('[role="status"]');
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(status.text()).toContain("件の発表を表示");
+  });
+
+  it("該当なしのときライブリージョンが空状態を伝える", () => {
+    const wrapper = mount(ChronicleView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        query: "not-found",
+        selectedSpeaker: "all",
+        selectedYear: "all",
+      },
+    });
+
+    expect(wrapper.find('[role="status"]').text()).toBe("該当するスピーカーが見つかりません。");
+    expect(wrapper.findAll("h2")).toHaveLength(0);
+  });
+});

--- a/src/components/ChronicleView.test.ts
+++ b/src/components/ChronicleView.test.ts
@@ -18,7 +18,8 @@ describe("ChronicleView", () => {
     expect(headings.map((heading) => heading.text())).toEqual(
       expect.arrayContaining(["2018全 1 発表", "2025全 2 発表"]),
     );
-    expect(wrapper.find("main#main").exists()).toBe(true);
+    // main ランドマークは island 側が所有するためビュー内には持たない
+    expect(wrapper.find("main").exists()).toBe(false);
     expect(wrapper.find('nav[aria-label="年度"]').exists()).toBe(true);
     expect(wrapper.find('a[href="#year-2018"]').exists()).toBe(true);
 

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -74,7 +74,7 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 </script>
 
 <template>
-  <main>
+  <main id="main" tabindex="-1">
     <section>
       <!-- スピーカー名・キーワードによるフィルターバー -->
       <SpeakerFilterBar
@@ -86,13 +86,33 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       />
       <!-- 開催年度によるフィルターバー -->
       <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+      <!-- フィルター結果のライブリージョン（件数変化と空状態を通知） -->
+      <p aria-atomic="true" aria-live="polite" class="sr-only" role="status">
+        {{ grouped.length === 0 ? t.empty : t.filter_result_talks(filtered.length) }}
+      </p>
       <!-- フィルター結果が0件のとき -->
       <div
         v-if="grouped.length === 0"
+        aria-hidden="true"
         class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
       >
         {{ t.empty }}
       </div>
+      <!-- 表示中の年度への目次 -->
+      <nav
+        v-if="grouped.length > 0"
+        class="flex flex-wrap gap-x-3 gap-y-1 px-pad-x py-3 border-b border-rule-soft font-mono text-[12px] tracking-[0.06em]"
+        :aria-label="t.year_toc"
+      >
+        <a
+          v-for="[year] in grouped"
+          :key="year"
+          class="text-ink-2 underline hover:text-ink hover:no-underline"
+          :href="`#year-${year}`"
+        >
+          {{ year }}
+        </a>
+      </nav>
       <!-- 年度グループリスト -->
       <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
         <!-- 各年度グループ -->
@@ -101,22 +121,19 @@ function updateSelectedYear(value: AcceptedYear | "all") {
           :key="year"
           class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
         >
-          <!-- 年度ラベル（スクロール時に上部に固定） -->
+          <!-- 年度見出し（スクロール時に上部に固定） -->
           <div
             class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
             :id="`year-${year}`"
           >
-            <!-- 年度テキスト（表示専用） -->
-            <span
-              aria-hidden="true"
-              class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink"
-            >
-              {{ year }}
-            </span>
-            <!-- その年のトーク総数 -->
-            <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
-              {{ t.year_total_talks(arr.length) }}
-            </span>
+            <h2 class="flex flex-col items-start m-0">
+              <span class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
+                {{ year }}
+              </span>
+              <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
+                {{ t.year_total_talks(arr.length) }}
+              </span>
+            </h2>
             <!-- 年度別ページへの矢印リンク -->
             <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
             <!-- @vize:ignore-start -->

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -74,154 +74,152 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 </script>
 
 <template>
-  <main id="main" tabindex="-1">
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- フィルター結果のライブリージョン（件数変化と空状態を通知） -->
-      <p aria-atomic="true" aria-live="polite" class="sr-only" role="status">
-        {{ grouped.length === 0 ? t.empty : t.filter_result_talks(filtered.length) }}
-      </p>
-      <!-- フィルター結果が0件のとき -->
-      <div
-        v-if="grouped.length === 0"
-        aria-hidden="true"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- フィルター結果のライブリージョン（件数変化と空状態を通知） -->
+    <p aria-atomic="true" aria-live="polite" class="sr-only" role="status">
+      {{ grouped.length === 0 ? t.empty : t.filter_result_talks(filtered.length) }}
+    </p>
+    <!-- フィルター結果が0件のとき -->
+    <div
+      v-if="grouped.length === 0"
+      aria-hidden="true"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- 表示中の年度への目次 -->
+    <nav
+      v-if="grouped.length > 0"
+      class="flex flex-wrap gap-x-3 gap-y-1 px-pad-x py-3 border-b border-rule-soft font-mono text-[12px] tracking-[0.06em]"
+      :aria-label="t.year_toc"
+    >
+      <a
+        v-for="[year] in grouped"
+        :key="year"
+        class="text-ink-2 underline hover:text-ink hover:no-underline"
+        :href="`#year-${year}`"
       >
-        {{ t.empty }}
-      </div>
-      <!-- 表示中の年度への目次 -->
-      <nav
-        v-if="grouped.length > 0"
-        class="flex flex-wrap gap-x-3 gap-y-1 px-pad-x py-3 border-b border-rule-soft font-mono text-[12px] tracking-[0.06em]"
-        :aria-label="t.year_toc"
+        {{ year }}
+      </a>
+    </nav>
+    <!-- 年度グループリスト -->
+    <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
+      <!-- 各年度グループ -->
+      <li
+        v-for="[year, arr] in grouped"
+        :key="year"
+        class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
       >
-        <a
-          v-for="[year] in grouped"
-          :key="year"
-          class="text-ink-2 underline hover:text-ink hover:no-underline"
-          :href="`#year-${year}`"
+        <!-- 年度見出し（スクロール時に上部に固定） -->
+        <div
+          class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
+          :id="`year-${year}`"
         >
-          {{ year }}
-        </a>
-      </nav>
-      <!-- 年度グループリスト -->
-      <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
-        <!-- 各年度グループ -->
-        <li
-          v-for="[year, arr] in grouped"
-          :key="year"
-          class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
-        >
-          <!-- 年度見出し（スクロール時に上部に固定） -->
-          <div
-            class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
-            :id="`year-${year}`"
+          <h2 class="flex flex-col items-start m-0">
+            <span class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
+              {{ year }}
+            </span>
+            <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
+              {{ t.year_total_talks(arr.length) }}
+            </span>
+          </h2>
+          <!-- 年度別ページへの矢印リンク -->
+          <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
+            :aria-label="`${year} speakers`"
+            :href="`/${year}`"
           >
-            <h2 class="flex flex-col items-start m-0">
-              <span class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
-                {{ year }}
+            →
+          </a>
+          <!-- @vize:ignore-end -->
+        </div>
+        <!-- その年のスピーカー行リスト -->
+        <ol class="list-none p-0 m-0 border-t border-rule-soft">
+          <!-- 各スピーカー行 -->
+          <li
+            v-for="(s, i) in arr"
+            :key="`${year}-${i}`"
+            class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
+          >
+            <!-- 行番号（表示専用） -->
+            <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
+              <span>
+                {{ String(i + 1).padStart(2, "0") }}
               </span>
-              <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
-                {{ t.year_total_talks(arr.length) }}
-              </span>
-            </h2>
-            <!-- 年度別ページへの矢印リンク -->
-            <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-              :aria-label="`${year} speakers`"
-              :href="`/${year}`"
-            >
-              →
-            </a>
-            <!-- @vize:ignore-end -->
-          </div>
-          <!-- その年のスピーカー行リスト -->
-          <ol class="list-none p-0 m-0 border-t border-rule-soft">
-            <!-- 各スピーカー行 -->
-            <li
-              v-for="(s, i) in arr"
-              :key="`${year}-${i}`"
-              class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
-            >
-              <!-- 行番号（表示専用） -->
-              <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
-                <span>
-                  {{ String(i + 1).padStart(2, "0") }}
-                </span>
-              </div>
-              <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
-                <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
-                <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
-                  <span v-for="(n, ni) in s.name" :key="n" class="contents">
-                    <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
-                      ×
-                    </span>
-                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                    <!-- @vize:ignore-start -->
-                    <a
-                      class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
-                      :href="`/speakers/${encodeURIComponent(n)}`"
-                    >
-                      <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
-                        {{ n }}
-                        <rt>
-                          {{ s.nameRuby[ni] }}
-                        </rt>
-                      </ruby>
-                      <span v-else>
-                        {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
-                      </span>
-                    </a>
-                    <!-- @vize:ignore-end -->
+            </div>
+            <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
+              <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
+              <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
+                <span v-for="(n, ni) in s.name" :key="n" class="contents">
+                  <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
+                    ×
                   </span>
-                </div>
-                <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
-                <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
                   <!-- @vize:ignore-start -->
                   <a
-                    v-if="s.title"
-                    class="text-ink-2 no-underline group hover:text-ink"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="s.url"
+                    class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
+                    :href="`/speakers/${encodeURIComponent(n)}`"
                   >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='s.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
-                    >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ s.title }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
+                    <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
+                      {{ n }}
+                      <rt>
+                        {{ s.nameRuby[ni] }}
+                      </rt>
+                    </ruby>
+                    <span v-else>
+                      {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
                     </span>
                   </a>
                   <!-- @vize:ignore-end -->
-                  <!-- タイトル未決定時のプレースホルダー -->
-                  <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
-                    {{ t.tbd }}
-                  </span>
-                </div>
+                </span>
               </div>
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </section>
-  </main>
+              <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
+              <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  v-if="s.title"
+                  class="text-ink-2 no-underline group hover:text-ink"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="s.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='s.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ s.title }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- タイトル未決定時のプレースホルダー -->
+                <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
+                  {{ t.tbd }}
+                </span>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/DirectoryView.test.ts
+++ b/src/components/DirectoryView.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakers } from "../../musea/sample-data";
+import DirectoryView from "./DirectoryView.vue";
+
+const defaultProps = {
+  allSpeakers: museaSpeakers,
+  query: "",
+  selectedSpeaker: "all",
+  selectedYear: "all" as const,
+};
+
+describe("DirectoryView", () => {
+  it("一覧見出しとソート状態・件数をプログラム的に伝える", () => {
+    const wrapper = mount(DirectoryView, { props: defaultProps });
+
+    const heading = wrapper.get("h2");
+    expect(heading.text()).toContain("スピーカー一覧");
+    expect(heading.text()).toContain("登壇回数の多い順");
+    expect(wrapper.get("ol[aria-labelledby]").attributes("aria-labelledby")).toBe(
+      heading.attributes("id"),
+    );
+
+    const sortButtons = wrapper.find('[role="group"][aria-label="並び替え"]').findAll("button");
+    expect(sortButtons[0]?.attributes("aria-pressed")).toBe("true");
+    expect(sortButtons[1]?.attributes("aria-pressed")).toBe("false");
+
+    const status = wrapper.get('[role="status"]');
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(status.text()).toMatch(/\d+件中\d+件を表示/);
+  });
+
+  it("行ボタンの名前を短くし年度グリッドを隠す", async () => {
+    const wrapper = mount(DirectoryView, { props: defaultProps });
+
+    const evan = wrapper
+      .findAll("button[aria-expanded]")
+      .find((button) => (button.attributes("aria-label") || "").includes("Evan You"));
+
+    expect(evan).toBeTruthy();
+    expect(evan?.attributes("aria-label")).toBe("Evan You、2回登壇、詳細を開く");
+    expect(evan?.attributes("aria-controls")).toBe(
+      `directory-panel-${encodeURIComponent("Evan You")}`,
+    );
+    expect(evan?.find('[aria-hidden="true"].inline-grid').exists()).toBe(true);
+    expect(evan?.text()).toContain("×2");
+
+    await evan?.trigger("click");
+    const opened = wrapper
+      .findAll("button[aria-expanded]")
+      .find((button) => (button.attributes("aria-label") || "").includes("Evan You"));
+    expect(opened?.attributes("aria-expanded")).toBe("true");
+    expect(opened?.attributes("aria-label")).toBe("Evan You、2回登壇、詳細を閉じる");
+    expect(wrapper.find(`[id="directory-panel-${encodeURIComponent("Evan You")}"]`).exists()).toBe(
+      true,
+    );
+  });
+
+  it("空状態をライブリージョンで通知する", () => {
+    const wrapper = mount(DirectoryView, {
+      props: { ...defaultProps, query: "not-found" },
+    });
+
+    expect(wrapper.get('[role="status"]').text()).toContain("該当するスピーカーが見つかりません。");
+  });
+});

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, useId } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
@@ -109,11 +109,42 @@ function updateSelectedSpeaker(value: string) {
 function updateSelectedYear(value: AcceptedYear | "all") {
   emit("update:selectedYear", value);
 }
+
+const sortLabel = computed(() => {
+  if (sort.value === "appearances") return t.value.sort_appearances;
+  if (sort.value === "latest") return t.value.sort_latest;
+  if (sort.value === "name-desc") return t.value.sort_name_desc;
+  return t.value.sort_name_asc;
+});
+
+const filterStatus = computed(() => {
+  const result = t.value.filter_result(filtered.value.length, allRecords.value.length);
+  if (filtered.value.length === 0) return `${result} ${t.value.empty}`;
+  return result;
+});
+
+function speakerDisplayName(rec: SpeakerRecord) {
+  return lang.value === "en" && rec.nameEn ? rec.nameEn : rec.name;
+}
+
+function rowLabel(rec: SpeakerRecord) {
+  return t.value.directory_row_label(
+    speakerDisplayName(rec),
+    rec.talks.length,
+    openRows.value.has(rec.name),
+  );
+}
+
+function directoryPanelId(name: string) {
+  return `directory-panel-${encodeURIComponent(name)}`;
+}
+
+const directoryHeadingId = useId();
 </script>
 
 <template>
   <!-- ディレクトリビュー：スピーカーを人物単位でまとめ、アコーディオンで登壇履歴を表示するビュー -->
-  <main>
+  <main id="main" tabindex="-1">
     <section>
       <!-- スピーカー名・キーワードによるフィルターバー -->
       <SpeakerFilterBar
@@ -125,57 +156,82 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       />
       <!-- 開催年度によるフィルターバー -->
       <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- Sort header -->
+      <!-- 一覧見出し（件数とソート状態を含む） -->
+      <h2
+        class="px-pad-x pt-4.5 pb-0 m-0 font-mono text-[12px] tracking-[0.06em] text-ink"
+        :id="directoryHeadingId"
+      >
+        {{ t.directory_heading(filtered.length, sortLabel) }}
+      </h2>
       <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
-      <div class="flex items-center gap-2 px-pad-x pt-4.5 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
-        <!-- 登壇回数の多い順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "appearances"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByAppearances"
+      <div class="flex items-center gap-2 px-pad-x pt-2 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
+        <div class="flex items-center gap-2" role="group" :aria-label="t.sort_label">
+          <!-- 登壇回数の多い順でソートするボタン -->
+          <button
+            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+            type="button"
+            :aria-pressed='sort === "appearances" ? "true" : "false"'
+            :class='sort === "appearances"
+              ? "bg-ink text-paper border-ink"
+              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+            @click="sortByAppearances"
+          >
+            {{ t.sort_appearances }}
+            <span v-if='sort === "appearances"' class="sr-only">
+              （{{ t.selected }}）
+            </span>
+          </button>
+          <!-- 名前の昇順/降順でソートするボタン -->
+          <button
+            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+            type="button"
+            :aria-pressed='sort === "name-asc" || sort === "name-desc" ? "true" : "false"'
+            :class='sort === "name-asc" || sort === "name-desc"
+              ? "bg-ink text-paper border-ink"
+              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+            @click="toggleNameSort"
+          >
+            {{ sort === "name-desc" ? t.sort_name_desc : t.sort_name_asc }}
+            <span v-if='sort === "name-asc" || sort === "name-desc"' class="sr-only">
+              （{{ t.selected }}）
+            </span>
+          </button>
+          <!-- 最新登壇年の新しい順でソートするボタン -->
+          <button
+            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+            type="button"
+            :aria-pressed='sort === "latest" ? "true" : "false"'
+            :class='sort === "latest"
+              ? "bg-ink text-paper border-ink"
+              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+            @click="sortByLatest"
+          >
+            {{ t.sort_latest }}
+            <span v-if='sort === "latest"' class="sr-only">
+              （{{ t.selected }}）
+            </span>
+          </button>
+        </div>
+        <!-- フィルター結果のライブリージョン -->
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap"
+          role="status"
         >
-          Appearances ↓
-        </button>
-        <!-- 名前の昇順/降順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "name-asc" || sort === "name-desc"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="toggleNameSort"
-        >
-          Name {{ sort === "name-desc" ? "Z→A" : "A→Z" }}
-        </button>
-        <!-- 最新登壇年の新しい順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "latest"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByLatest"
-        >
-          Latest year ↓
-        </button>
-        <!-- フィルター済み件数 / 全体件数の表示 -->
-        <span class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap">
-          {{ String(filtered.length).padStart(3, "0") }} /
-          {{ String(allRecords.length).padStart(3, "0") }}
+          {{ filterStatus }}
         </span>
       </div>
-      <!-- フィルター結果が0件のときの空状態メッセージ -->
+      <!-- フィルター結果が0件のときの空状態メッセージ（ライブリージョンと二重読み上げしない） -->
       <div
         v-if="filtered.length === 0"
+        aria-hidden="true"
         class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
       >
         {{ t.empty }}
       </div>
       <!-- スピーカー一覧リスト -->
-      <ol class="list-none p-0 m-0">
+      <ol class="list-none p-0 m-0" :aria-labelledby="directoryHeadingId">
         <li
           v-for="(rec, i) in filtered"
           :key="rec.name"
@@ -186,7 +242,9 @@ function updateSelectedYear(value: AcceptedYear | "all") {
           <button
             class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
             type="button"
+            :aria-controls="directoryPanelId(rec.name)"
             :aria-expanded="openRows.has(rec.name)"
+            :aria-label="rowLabel(rec)"
             :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
             @click="() => toggleRow(rec.name)"
           >
@@ -197,6 +255,7 @@ function updateSelectedYear(value: AcceptedYear | "all") {
               </span>
               <!-- スピーカー名（振り仮名・英語名対応） -->
               <span
+                aria-hidden="true"
                 class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
                 :lang='hasJapanese(rec.name) ? "ja" : "en"'
               >
@@ -209,18 +268,18 @@ function updateSelectedYear(value: AcceptedYear | "all") {
                 <template v-else>
                   {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
                 </template>
-                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示。formatter の改行空白を避けるため data-count で描画） -->
+                <!-- 複数回登壇バッジ（実 DOM テキストで描画） -->
                 <span
                   v-if="rec.talks.length > 1"
-                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px] after:content-[attr(data-count)]"
-                  :aria-label="t.appearance_count(rec.talks.length)"
-                  :data-count="`×${rec.talks.length}`"
-                ></span>
+                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
+                >
+                  ×{{ rec.talks.length }}
+                </span>
               </span>
-              <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
+              <!-- 登壇年度グリッド（名前は行ボタンの aria-label に集約） -->
               <span
+                aria-hidden="true"
                 class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
-                :aria-label='t.years_appeared + ": " + rec.years.join(", ")'
               >
                 <span
                   v-for="y in YEARS"
@@ -251,6 +310,7 @@ function updateSelectedYear(value: AcceptedYear | "all") {
           <div
             v-if="openRows.has(rec.name)"
             class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
+            :id="directoryPanelId(rec.name)"
           >
             <!-- スピーカープロフィールページへのリンク -->
             <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -144,252 +144,250 @@ const directoryHeadingId = useId();
 
 <template>
   <!-- ディレクトリビュー：スピーカーを人物単位でまとめ、アコーディオンで登壇履歴を表示するビュー -->
-  <main id="main" tabindex="-1">
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- 一覧見出し（件数とソート状態を含む） -->
-      <h2
-        class="px-pad-x pt-4.5 pb-0 m-0 font-mono text-[12px] tracking-[0.06em] text-ink"
-        :id="directoryHeadingId"
-      >
-        {{ t.directory_heading(filtered.length, sortLabel) }}
-      </h2>
-      <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
-      <div class="flex items-center gap-2 px-pad-x pt-2 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
-        <div class="flex items-center gap-2" role="group" :aria-label="t.sort_label">
-          <!-- 登壇回数の多い順でソートするボタン -->
-          <button
-            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-            type="button"
-            :aria-pressed='sort === "appearances" ? "true" : "false"'
-            :class='sort === "appearances"
-              ? "bg-ink text-paper border-ink"
-              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-            @click="sortByAppearances"
-          >
-            {{ t.sort_appearances }}
-            <span v-if='sort === "appearances"' class="sr-only">
-              （{{ t.selected }}）
-            </span>
-          </button>
-          <!-- 名前の昇順/降順でソートするボタン -->
-          <button
-            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-            type="button"
-            :aria-pressed='sort === "name-asc" || sort === "name-desc" ? "true" : "false"'
-            :class='sort === "name-asc" || sort === "name-desc"
-              ? "bg-ink text-paper border-ink"
-              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-            @click="toggleNameSort"
-          >
-            {{ sort === "name-desc" ? t.sort_name_desc : t.sort_name_asc }}
-            <span v-if='sort === "name-asc" || sort === "name-desc"' class="sr-only">
-              （{{ t.selected }}）
-            </span>
-          </button>
-          <!-- 最新登壇年の新しい順でソートするボタン -->
-          <button
-            class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-            type="button"
-            :aria-pressed='sort === "latest" ? "true" : "false"'
-            :class='sort === "latest"
-              ? "bg-ink text-paper border-ink"
-              : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-            @click="sortByLatest"
-          >
-            {{ t.sort_latest }}
-            <span v-if='sort === "latest"' class="sr-only">
-              （{{ t.selected }}）
-            </span>
-          </button>
-        </div>
-        <!-- フィルター結果のライブリージョン -->
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap"
-          role="status"
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- 一覧見出し（件数とソート状態を含む） -->
+    <h2
+      class="px-pad-x pt-4.5 pb-0 m-0 font-mono text-[12px] tracking-[0.06em] text-ink"
+      :id="directoryHeadingId"
+    >
+      {{ t.directory_heading(filtered.length, sortLabel) }}
+    </h2>
+    <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
+    <div class="flex items-center gap-2 px-pad-x pt-2 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
+      <div class="flex items-center gap-2" role="group" :aria-label="t.sort_label">
+        <!-- 登壇回数の多い順でソートするボタン -->
+        <button
+          class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+          type="button"
+          :aria-pressed='sort === "appearances" ? "true" : "false"'
+          :class='sort === "appearances"
+            ? "bg-ink text-paper border-ink"
+            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+          @click="sortByAppearances"
         >
-          {{ filterStatus }}
-        </span>
-      </div>
-      <!-- フィルター結果が0件のときの空状態メッセージ（ライブリージョンと二重読み上げしない） -->
-      <div
-        v-if="filtered.length === 0"
-        aria-hidden="true"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
-      >
-        {{ t.empty }}
-      </div>
-      <!-- スピーカー一覧リスト -->
-      <ol class="list-none p-0 m-0" :aria-labelledby="directoryHeadingId">
-        <li
-          v-for="(rec, i) in filtered"
-          :key="rec.name"
-          class="border-b border-rule-softer"
-          :data-open='openRows.has(rec.name) ? "true" : "false"'
+          {{ t.sort_appearances }}
+          <span v-if='sort === "appearances"' class="sr-only">
+            （{{ t.selected }}）
+          </span>
+        </button>
+        <!-- 名前の昇順/降順でソートするボタン -->
+        <button
+          class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+          type="button"
+          :aria-pressed='sort === "name-asc" || sort === "name-desc" ? "true" : "false"'
+          :class='sort === "name-asc" || sort === "name-desc"
+            ? "bg-ink text-paper border-ink"
+            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+          @click="toggleNameSort"
         >
-          <!-- スピーカー行の展開/折りたたみボタン -->
-          <button
-            class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
-            type="button"
-            :aria-controls="directoryPanelId(rec.name)"
-            :aria-expanded="openRows.has(rec.name)"
-            :aria-label="rowLabel(rec)"
-            :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
-            @click="() => toggleRow(rec.name)"
-          >
-            <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
-              <!-- 行番号（表示専用） -->
-              <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
-                {{ String(i + 1).padStart(3, "0") }}
-              </span>
-              <!-- スピーカー名（振り仮名・英語名対応） -->
-              <span
-                aria-hidden="true"
-                class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
-                :lang='hasJapanese(rec.name) ? "ja" : "en"'
-              >
-                <ruby v-if='rec.nameRuby && lang === "ja"'>
-                  {{ rec.name }}
-                  <rt>
-                    {{ rec.nameRuby }}
-                  </rt>
-                </ruby>
-                <template v-else>
-                  {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-                </template>
-                <!-- 複数回登壇バッジ（実 DOM テキストで描画） -->
-                <span
-                  v-if="rec.talks.length > 1"
-                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
-                >
-                  ×{{ rec.talks.length }}
-                </span>
-              </span>
-              <!-- 登壇年度グリッド（名前は行ボタンの aria-label に集約） -->
-              <span
-                aria-hidden="true"
-                class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
-              >
-                <span
-                  v-for="y in YEARS"
-                  :key="y"
-                  class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
-                  :class='[
-                    rec.years.includes(y) && selectedYear === y
-                      ? "bg-accent border border-accent text-accent-ink"
-                      : rec.years.includes(y)
-                        ? "bg-ink border border-ink text-paper"
-                        : "border border-ink text-ink",
-                  ]'
-                  :title="y"
-                >
-                  {{ y.slice(-2) }}
-                </span>
-              </span>
+          {{ sort === "name-desc" ? t.sort_name_desc : t.sort_name_asc }}
+          <span v-if='sort === "name-asc" || sort === "name-desc"' class="sr-only">
+            （{{ t.selected }}）
+          </span>
+        </button>
+        <!-- 最新登壇年の新しい順でソートするボタン -->
+        <button
+          class="text-[12px] tracking-[0.06em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+          type="button"
+          :aria-pressed='sort === "latest" ? "true" : "false"'
+          :class='sort === "latest"
+            ? "bg-ink text-paper border-ink"
+            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+          @click="sortByLatest"
+        >
+          {{ t.sort_latest }}
+          <span v-if='sort === "latest"' class="sr-only">
+            （{{ t.selected }}）
+          </span>
+        </button>
+      </div>
+      <!-- フィルター結果のライブリージョン -->
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap"
+        role="status"
+      >
+        {{ filterStatus }}
+      </span>
+    </div>
+    <!-- フィルター結果が0件のときの空状態メッセージ（ライブリージョンと二重読み上げしない） -->
+    <div
+      v-if="filtered.length === 0"
+      aria-hidden="true"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- スピーカー一覧リスト -->
+    <ol class="list-none p-0 m-0" :aria-labelledby="directoryHeadingId">
+      <li
+        v-for="(rec, i) in filtered"
+        :key="rec.name"
+        class="border-b border-rule-softer"
+        :data-open='openRows.has(rec.name) ? "true" : "false"'
+      >
+        <!-- スピーカー行の展開/折りたたみボタン -->
+        <button
+          class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
+          type="button"
+          :aria-controls="directoryPanelId(rec.name)"
+          :aria-expanded="openRows.has(rec.name)"
+          :aria-label="rowLabel(rec)"
+          :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
+          @click="() => toggleRow(rec.name)"
+        >
+          <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
+            <!-- 行番号（表示専用） -->
+            <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
+              {{ String(i + 1).padStart(3, "0") }}
             </span>
-            <!-- 展開/折りたたみアイコン（+/−） -->
+            <!-- スピーカー名（振り仮名・英語名対応） -->
             <span
               aria-hidden="true"
-              class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+              class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
+              :lang='hasJapanese(rec.name) ? "ja" : "en"'
             >
-              {{ openRows.has(rec.name) ? "−" : "+" }}
-            </span>
-          </button>
-          <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
-          <div
-            v-if="openRows.has(rec.name)"
-            class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
-            :id="directoryPanelId(rec.name)"
-          >
-            <!-- スピーカープロフィールページへのリンク -->
-            <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
-              :href="`/speakers/${encodeURIComponent(rec.name)}`"
-            >
-              {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-            </a>
-            <!-- @vize:ignore-end -->
-            <!-- 登壇一覧リスト -->
-            <ol class="list-none p-0 m-0 mt-[14px]">
-              <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
-              <li
-                v-for="(talk, k) in rec.talks"
-                :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-                class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
-                :class='k === 0 ? "border-t-0" : ""'
+              <ruby v-if='rec.nameRuby && lang === "ja"'>
+                {{ rec.name }}
+                <rt>
+                  {{ rec.nameRuby }}
+                </rt>
+              </ruby>
+              <template v-else>
+                {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+              </template>
+              <!-- 複数回登壇バッジ（実 DOM テキストで描画） -->
+              <span
+                v-if="rec.talks.length > 1"
+                class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
               >
-                <!-- 開催年リンク（年度別ページへ） -->
-                <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+                ×{{ rec.talks.length }}
+              </span>
+            </span>
+            <!-- 登壇年度グリッド（名前は行ボタンの aria-label に集約） -->
+            <span
+              aria-hidden="true"
+              class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
+            >
+              <span
+                v-for="y in YEARS"
+                :key="y"
+                class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
+                :class='[
+                  rec.years.includes(y) && selectedYear === y
+                    ? "bg-accent border border-accent text-accent-ink"
+                    : rec.years.includes(y)
+                      ? "bg-ink border border-ink text-paper"
+                      : "border border-ink text-ink",
+                ]'
+                :title="y"
+              >
+                {{ y.slice(-2) }}
+              </span>
+            </span>
+          </span>
+          <!-- 展開/折りたたみアイコン（+/−） -->
+          <span
+            aria-hidden="true"
+            class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+          >
+            {{ openRows.has(rec.name) ? "−" : "+" }}
+          </span>
+        </button>
+        <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
+        <div
+          v-if="openRows.has(rec.name)"
+          class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
+          :id="directoryPanelId(rec.name)"
+        >
+          <!-- スピーカープロフィールページへのリンク -->
+          <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
+            :href="`/speakers/${encodeURIComponent(rec.name)}`"
+          >
+            {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+          </a>
+          <!-- @vize:ignore-end -->
+          <!-- 登壇一覧リスト -->
+          <ol class="list-none p-0 m-0 mt-[14px]">
+            <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
+            <li
+              v-for="(talk, k) in rec.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
+              :class='k === 0 ? "border-t-0" : ""'
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+              <!-- @vize:ignore-start -->
+              <a
+                class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
+                :href="`/${talk.year}`"
+              >
+                {{ talk.year }}
+              </a>
+              <!-- @vize:ignore-end -->
+              <div class="flex flex-col gap-y-[8px]">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
                 <!-- @vize:ignore-start -->
                 <a
-                  class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
-                  :href="`/${talk.year}`"
+                  class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
                 >
-                  {{ talk.year }}
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ talk.title || t.tbd }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
                 </a>
                 <!-- @vize:ignore-end -->
-                <div class="flex flex-col gap-y-[8px]">
-                  <!-- トークタイトル（外部リンク） -->
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="talk.url"
-                  >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='talk.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
+                    <template v-if="ci > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
+                      :href="`/speakers/${encodeURIComponent(cn)}`"
                     >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ talk.title || t.tbd }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
-                    </span>
-                  </a>
-                  <!-- @vize:ignore-end -->
-                  <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-                  <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                    w/
-                    <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
-                      <template v-if="ci > 0">
-                        ,
-                      </template>
-                      <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                      <!-- @vize:ignore-start -->
-                      <a
-                        class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
-                        :href="`/speakers/${encodeURIComponent(cn)}`"
-                      >
-                        {{ cn }}
-                      </a>
-                      <!-- @vize:ignore-end -->
-                    </span>
+                      {{ cn }}
+                    </a>
+                    <!-- @vize:ignore-end -->
                   </span>
-                </div>
-              </li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </section>
-  </main>
+                </span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/SkipLinks.test.ts
+++ b/src/components/SkipLinks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import SkipLinks from "./SkipLinks.vue";
+
+describe("SkipLinks", () => {
+  it("本文へのスキップリンクを先頭に置き slot でリンクを追加できる", () => {
+    const wrapper = mount(SkipLinks, {
+      slots: {
+        default: '<a class="skip-link" href="#site-footer">フッターへ</a>',
+      },
+    });
+
+    const links = wrapper.findAll("a.skip-link");
+    expect(wrapper.get("nav").attributes("aria-label")).toBe("スキップリンク");
+    expect(links[0]?.attributes("href")).toBe("#main");
+    expect(links[0]?.text()).toBe("本文へ");
+    expect(links[1]?.attributes("href")).toBe("#site-footer");
+  });
+});

--- a/src/components/SkipLinks.vue
+++ b/src/components/SkipLinks.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { useVfjsI18n } from "../composables/useVfjsI18n";
+
+const { t } = useVfjsI18n();
+</script>
+
+<template>
+  <!-- 本文へジャンプするスキップリンク（フォーカス時のみ表示）。ページ固有のリンクは slot で追加する -->
+  <nav class="skip-links" :aria-label="t.skip_links">
+    <a class="skip-link" href="#main">
+      {{ t.skip_to_main }}
+    </a>
+    <slot />
+  </nav>
+</template>

--- a/src/components/YearFilterBar.test.ts
+++ b/src/components/YearFilterBar.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import YearFilterBar from "./YearFilterBar.vue";
+
+const counts = {
+  all: 10,
+  2018: 2,
+  2019: 0,
+  2022: 1,
+  2023: 1,
+  2024: 2,
+  2025: 2,
+  2026: 2,
+};
+
+describe("YearFilterBar", () => {
+  it("選択中の年度ボタンに aria-pressed を付ける", () => {
+    const wrapper = mount(YearFilterBar, {
+      props: { selectedYear: "2025", counts },
+    });
+
+    const buttons = wrapper.findAll("button");
+    const allButton = buttons.find((button) => button.text().includes("ALL"));
+    const yearButton = buttons.find((button) => button.text().includes("2025"));
+
+    expect(allButton?.attributes("aria-pressed")).toBe("false");
+    expect(yearButton?.attributes("aria-pressed")).toBe("true");
+    expect(yearButton?.text()).toContain("選択中");
+  });
+});

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useId } from "vue";
 import { YEARS } from "../../types";
 import type { AcceptedYear } from "../../types";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
@@ -13,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useVfjsI18n();
+const yearFilterLabelId = useId();
 
 function selectAllYears() {
   emit("update:selectedYear", "all");
@@ -27,10 +29,11 @@ function selectYear(year: AcceptedYear) {
   <div class="px-pad-x py-3.5 border-b border-rule-soft" role="region" :aria-label="t.filter_year">
     <!-- 年度選択ボタングループ -->
     <div class="flex items-center flex-wrap gap-1.5">
-      <span class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
+      <span :id="yearFilterLabelId" class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
         {{ t.filter_year }}
       </span>
-      <div class="flex gap-1.5 flex-wrap" role="group" :aria-label="t.filter_year">
+      <!-- group の名前は可視ラベルを参照する（region の aria-label と重複させない） -->
+      <div class="flex gap-1.5 flex-wrap" role="group" :aria-labelledby="yearFilterLabelId">
         <!-- 全年度選択ボタン（スピーカー総数を表示） -->
         <button
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -35,6 +35,7 @@ function selectYear(year: AcceptedYear) {
         <button
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === "all" ? "true" : "false"'
           :class='selectedYear === "all"
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
@@ -42,6 +43,9 @@ function selectYear(year: AcceptedYear) {
           @click="selectAllYears"
         >
           ALL · {{ counts.all }}
+          <span v-if='selectedYear === "all"' class="sr-only">
+            （{{ t.selected }}）
+          </span>
         </button>
         <!-- 各開催年ごとの選択ボタン（その年のスピーカー数を表示） -->
         <button
@@ -49,6 +53,7 @@ function selectYear(year: AcceptedYear) {
           :key="y"
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === y ? "true" : "false"'
           :class='selectedYear === y
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
@@ -56,6 +61,9 @@ function selectYear(year: AcceptedYear) {
           @click="() => selectYear(y)"
         >
           {{ y }} · {{ counts[y] }}
+          <span v-if="selectedYear === y" class="sr-only">
+            （{{ t.selected }}）
+          </span>
         </button>
       </div>
     </div>

--- a/src/composables/useVfjsI18n.ts
+++ b/src/composables/useVfjsI18n.ts
@@ -13,6 +13,7 @@ export interface VfjsTranslations {
   filter_search_ph: string;
   view_timeline: string;
   view_index: string;
+  view_mode: string;
   language: string;
   color_scheme: string;
   color_scheme_light: string;
@@ -30,8 +31,22 @@ export interface VfjsTranslations {
   all_speakers: string;
   not_found_title: string;
   not_found_description: string;
+  skip_links: string;
+  skip_to_main: string;
+  skip_to_footer: string;
+  year_toc: string;
+  sort_label: string;
+  sort_appearances: string;
+  sort_name_asc: string;
+  sort_name_desc: string;
+  sort_latest: string;
+  selected: string;
   year_total_talks: (n: number) => string;
   appearance_count: (n: number) => string;
+  directory_heading: (count: number, sortLabel: string) => string;
+  filter_result: (shown: number, total: number) => string;
+  filter_result_talks: (n: number) => string;
+  directory_row_label: (name: string, count: number, expanded: boolean) => string;
 }
 
 const translations: Record<"ja" | "en", VfjsTranslations> = {
@@ -49,6 +64,7 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_search_ph: "発表タイトル・スピーカー名で検索",
     view_timeline: "タイムライン",
     view_index: "スピーカー",
+    view_mode: "表示切替",
     language: "言語",
     color_scheme: "配色",
     color_scheme_light: "ライト",
@@ -66,8 +82,23 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     all_speakers: "発表者一覧",
     not_found_title: "ページが見つかりません",
     not_found_description: "指定されたページは存在しないか、移動した可能性があります。",
+    skip_links: "スキップリンク",
+    skip_to_main: "本文へ",
+    skip_to_footer: "フッターへ",
+    year_toc: "年度",
+    sort_label: "並び替え",
+    sort_appearances: "登壇回数の多い順",
+    sort_name_asc: "名前順（A→Z）",
+    sort_name_desc: "名前順（Z→A）",
+    sort_latest: "最新年の新しい順",
+    selected: "選択中",
     year_total_talks: (n: number) => `全 ${n} 発表`,
     appearance_count: (n: number) => `${n}回登壇`,
+    directory_heading: (count, sortLabel) => `スピーカー一覧（${count}名・${sortLabel}）`,
+    filter_result: (shown, total) => `${total}件中${shown}件を表示`,
+    filter_result_talks: (n) => `${n}件の発表を表示`,
+    directory_row_label: (name, count, expanded) =>
+      `${name}、${count}回登壇、${expanded ? "詳細を閉じる" : "詳細を開く"}`,
   },
   en: {
     nav_all_label: "All speakers",
@@ -83,6 +114,7 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_search_ph: "Search talk titles or speaker names",
     view_timeline: "Timeline",
     view_index: "Speakers",
+    view_mode: "View mode",
     language: "Language",
     color_scheme: "Color scheme",
     color_scheme_light: "Light",
@@ -100,8 +132,23 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     all_speakers: "Speakers",
     not_found_title: "Page Not Found",
     not_found_description: "The page you requested does not exist or may have moved.",
+    skip_links: "Skip links",
+    skip_to_main: "Skip to main content",
+    skip_to_footer: "Skip to footer",
+    year_toc: "Years",
+    sort_label: "Sort",
+    sort_appearances: "Most appearances",
+    sort_name_asc: "Name A to Z",
+    sort_name_desc: "Name Z to A",
+    sort_latest: "Latest year",
+    selected: "selected",
     year_total_talks: (n: number) => `${n} talks total`,
     appearance_count: (n: number) => `${n} appearance${n > 1 ? "s" : ""}`,
+    directory_heading: (count, sortLabel) => `Speakers (${count}, ${sortLabel})`,
+    filter_result: (shown, total) => `Showing ${shown} of ${total}`,
+    filter_result_talks: (n) => `Showing ${n} talks`,
+    directory_row_label: (name, count, expanded) =>
+      `${name}, ${count} appearance${count > 1 ? "s" : ""}, ${expanded ? "Collapse details" : "Expand details"}`,
   },
 };
 

--- a/src/islands/HomePageIsland.test.ts
+++ b/src/islands/HomePageIsland.test.ts
@@ -29,6 +29,10 @@ describe("HomePageIsland", () => {
     expect(tabs[0]?.attributes("aria-controls")).toBe(panel.attributes("id"));
     expect(panel.attributes("aria-labelledby")).toBe(tabs[0]?.attributes("id"));
 
+    // タブパネルはスキップリンク先の main ランドマーク内に置く
+    const main = wrapper.get("main#main");
+    expect(main.find('[role="tabpanel"]').exists()).toBe(true);
+
     wrapper.unmount();
   });
 

--- a/src/islands/HomePageIsland.test.ts
+++ b/src/islands/HomePageIsland.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { flushPromises, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { museaSpeakers } from "../../musea/sample-data";
+import HomePageIsland from "./HomePageIsland.vue";
+
+describe("HomePageIsland", () => {
+  afterEach(() => {
+    localStorage.removeItem("vfjs:view");
+  });
+
+  it("表示切替タブを APG Tabs として関連付ける", () => {
+    const wrapper = mount(HomePageIsland, {
+      props: { allSpeakers: museaSpeakers },
+      attachTo: document.body,
+    });
+
+    const tablist = wrapper.get('[role="tablist"]');
+    expect(tablist.attributes("aria-label")).toBe("表示切替");
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]?.attributes("aria-selected")).toBe("true");
+    expect(tabs[0]?.attributes("tabindex")).toBe("0");
+    expect(tabs[1]?.attributes("aria-selected")).toBe("false");
+    expect(tabs[1]?.attributes("tabindex")).toBe("-1");
+
+    const panel = wrapper.get('[role="tabpanel"]');
+    expect(tabs[0]?.attributes("aria-controls")).toBe(panel.attributes("id"));
+    expect(panel.attributes("aria-labelledby")).toBe(tabs[0]?.attributes("id"));
+
+    wrapper.unmount();
+  });
+
+  it("矢印キーでタブを切り替え非選択タブを tabindex=-1 にする", async () => {
+    const wrapper = mount(HomePageIsland, {
+      props: { allSpeakers: museaSpeakers },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    await tabs[0]?.trigger("keydown", { key: "ArrowRight" });
+    await nextTick();
+
+    const updatedTabs = wrapper.findAll('[role="tab"]');
+    expect(updatedTabs[0]?.attributes("aria-selected")).toBe("false");
+    expect(updatedTabs[0]?.attributes("tabindex")).toBe("-1");
+    expect(updatedTabs[1]?.attributes("aria-selected")).toBe("true");
+    expect(updatedTabs[1]?.attributes("tabindex")).toBe("0");
+    expect(wrapper.get('[role="tabpanel"]').attributes("aria-labelledby")).toBe(
+      updatedTabs[1]?.attributes("id"),
+    );
+
+    wrapper.unmount();
+  });
+});

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, useId, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -43,12 +43,47 @@ const stats = computed(() => {
   };
 });
 
+const tabOrder = ["chronicle", "index"] as const;
+type ViewMode = (typeof tabOrder)[number];
+
+const chronicleTabRef = ref<HTMLButtonElement | null>(null);
+const directoryTabRef = ref<HTMLButtonElement | null>(null);
+const tabChronicleId = useId();
+const tabDirectoryId = useId();
+const panelChronicleId = useId();
+const panelDirectoryId = useId();
+
 function showChronicle() {
   view.value = "chronicle";
 }
 
 function showDirectory() {
   view.value = "index";
+}
+
+function focusViewTab(next: ViewMode) {
+  nextTick(() => {
+    (next === "chronicle" ? chronicleTabRef.value : directoryTabRef.value)?.focus();
+  });
+}
+
+function onTabKeydown(event: KeyboardEvent) {
+  const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"];
+  if (!keys.includes(event.key)) return;
+  event.preventDefault();
+  const currentIndex = tabOrder.indexOf(view.value);
+  let next: ViewMode;
+  if (event.key === "Home") {
+    next = tabOrder[0];
+  } else if (event.key === "End") {
+    next = tabOrder[tabOrder.length - 1];
+  } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+    next = tabOrder[(currentIndex + 1) % tabOrder.length];
+  } else {
+    next = tabOrder[(currentIndex - 1 + tabOrder.length) % tabOrder.length];
+  }
+  view.value = next;
+  focusViewTab(next);
 }
 
 function updateQuery(value: string) {
@@ -71,20 +106,25 @@ function updateSelectedYear(value: AcceptedYear | "all") {
     <AppMasthead :stats />
     <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
     <div
-      aria-label="View mode"
       class="flex gap-0 px-pad-x border-b border-rule bg-paper"
       role="tablist"
+      :aria-label="t.view_mode"
     >
       <!-- 年度別クロニクルビュータブ -->
       <button
+        ref="chronicleTabRef"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :id="tabChronicleId"
+        :aria-controls="panelChronicleId"
         :aria-selected='view === "chronicle"'
+        :tabindex='view === "chronicle" ? 0 : -1'
         :class='view === "chronicle"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showChronicle"
+        @keydown="onTabKeydown"
       >
         {{ t.view_timeline }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -93,14 +133,19 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       </button>
       <!-- スピーカー名索引ディレクトリビュータブ -->
       <button
+        ref="directoryTabRef"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :id="tabDirectoryId"
+        :aria-controls="panelDirectoryId"
         :aria-selected='view === "index"'
+        :tabindex='view === "index" ? 0 : -1'
         :class='view === "index"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showDirectory"
+        @keydown="onTabKeydown"
       >
         {{ t.view_index }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -110,27 +155,35 @@ function updateSelectedYear(value: AcceptedYear | "all") {
     </div>
     <!-- 選択中のビューに応じてコンポーネントを切り替え -->
     <!-- 年度別クロニクルビュー -->
-    <ChronicleView
+    <div
       v-if='view === "chronicle"'
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
+      role="tabpanel"
+      tabindex="0"
+      :id="panelChronicleId"
+      :aria-labelledby="tabChronicleId"
+    >
+      <ChronicleView
+        :all-speakers
+        :query
+        :selected-speaker
+        :selected-year
+        @update:query="updateQuery"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:selected-year="updateSelectedYear"
+      />
+    </div>
     <!-- スピーカー索引ディレクトリビュー -->
-    <DirectoryView
-      v-else
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
+    <div v-else role="tabpanel" tabindex="0" :id="panelDirectoryId" :aria-labelledby="tabDirectoryId">
+      <DirectoryView
+        :all-speakers
+        :query
+        :selected-speaker
+        :selected-year
+        @update:query="updateQuery"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:selected-year="updateSelectedYear"
+      />
+    </div>
     <AppFooter />
   </div>
 </template>

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -153,37 +153,38 @@ function updateSelectedYear(value: AcceptedYear | "all") {
         </span>
       </button>
     </div>
-    <!-- 選択中のビューに応じてコンポーネントを切り替え -->
-    <!-- 年度別クロニクルビュー -->
-    <div
-      v-if='view === "chronicle"'
-      role="tabpanel"
-      tabindex="0"
-      :id="panelChronicleId"
-      :aria-labelledby="tabChronicleId"
-    >
-      <ChronicleView
-        :all-speakers
-        :query
-        :selected-speaker
-        :selected-year
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-        @update:selected-year="updateSelectedYear"
-      />
-    </div>
-    <!-- スピーカー索引ディレクトリビュー -->
-    <div v-else role="tabpanel" tabindex="0" :id="panelDirectoryId" :aria-labelledby="tabDirectoryId">
-      <DirectoryView
-        :all-speakers
-        :query
-        :selected-speaker
-        :selected-year
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-        @update:selected-year="updateSelectedYear"
-      />
-    </div>
+    <!-- 選択中のビューに応じてコンポーネントを切り替え（main ランドマークは island が所有） -->
+    <main id="main" tabindex="-1">
+      <!-- 年度別クロニクルビュー -->
+      <div
+        v-if='view === "chronicle"'
+        role="tabpanel"
+        :id="panelChronicleId"
+        :aria-labelledby="tabChronicleId"
+      >
+        <ChronicleView
+          :all-speakers
+          :query
+          :selected-speaker
+          :selected-year
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
+      <!-- スピーカー索引ディレクトリビュー -->
+      <div v-else role="tabpanel" :id="panelDirectoryId" :aria-labelledby="tabDirectoryId">
+        <DirectoryView
+          :all-speakers
+          :query
+          :selected-speaker
+          :selected-year
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
+    </main>
     <AppFooter />
   </div>
 </template>

--- a/src/islands/SpeakerPageIsland.vue
+++ b/src/islands/SpeakerPageIsland.vue
@@ -43,132 +43,134 @@ const record = computed(() => {
 <template>
   <div>
     <AppHeader />
-    <!-- スピーカーページのメインコンテンツ（該当スピーカーが存在する場合） -->
-    <template v-if="found">
-      <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
-      <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
-        <!-- スピーカー名 -->
-        <h1
-          class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
-          :lang='hasJapanese(record.name) ? "ja" : "en"'
-        >
-          <ruby v-if='record.nameRuby && lang === "ja"'>
-            {{ record.name }}
-            <rt>
-              {{ record.nameRuby }}
-            </rt>
-          </ruby>
-          <template v-else>
-            {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
-          </template>
-        </h1>
-        <div class="font-mono text-ink-2">
-          <!-- 総登壇回数 -->
-          <div>
-            {{ t.appearance_count(record.talks.length) }}
-          </div>
-          <!-- 登壇年度のリスト（各年度ページへのリンク） -->
-          <div class="mt-2 text-[12px] text-ink-2">
-            {{ t.years_appeared }}:
-            <span v-for="(year, index) in record.years" :key="year">
-              <template v-if="index > 0">
-                ,
-              </template>
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${year}`">
-                {{ year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-          </div>
-        </div>
-      </header>
-      <!-- 関連トーク一覧セクション -->
-      <section class="px-pad-x py-10">
-        <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
-          {{ t.related_talks }}
-        </h2>
-        <ul class="list-none p-0 m-0">
-          <li
-            v-for="talk in record.talks"
-            :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-            class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+    <!-- スピーカーページのメインコンテンツ -->
+    <main id="main" tabindex="-1">
+      <template v-if="found">
+        <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
+        <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
+          <!-- スピーカー名 -->
+          <h1
+            class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
+            :lang='hasJapanese(record.name) ? "ja" : "en"'
           >
-            <!-- 開催年リンク（年度別ページへ） -->
-            <span class="font-mono text-[12px] text-center pt-[3px]">
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
-                {{ talk.year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-            <div class="flex flex-col gap-y-2">
-              <!-- トークタイトル（外部リンク） -->
-              <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-              <!-- @vize:ignore-start -->
-              <a
-                class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
-                rel="noopener noreferrer"
-                target="_blank"
-                :href="talk.url"
-              >
-                <!-- パネルセッションのフォーマットバッジ -->
-                <span
-                  v-if='talk.format === "panel"'
-                  class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
-                >
-                  {{ t.session_format_panel }}
-                </span>
-                <span>
-                  <span
-                    class="group-hover:underline"
-                    :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
-                  >
-                    {{ talk.title || t.tbd }}
-                  </span>
-                  <span class="text-[10px] ml-1">
-                    ({{ t.external }})
-                  </span>
-                </span>
-              </a>
-              <!-- @vize:ignore-end -->
-              <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-              <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                w/
-                <span
-                  v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
-                  :key="coSpeakerName"
-                  class="contents"
-                >
-                  <template v-if="coSpeakerIndex > 0">
-                    ,
-                  </template>
-                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-ink underline hover:no-underline"
-                    :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
-                  >
-                    {{ coSpeakerName }}
-                  </a>
-                  <!-- @vize:ignore-end -->
-                </span>
+            <ruby v-if='record.nameRuby && lang === "ja"'>
+              {{ record.name }}
+              <rt>
+                {{ record.nameRuby }}
+              </rt>
+            </ruby>
+            <template v-else>
+              {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
+            </template>
+          </h1>
+          <div class="font-mono text-ink-2">
+            <!-- 総登壇回数 -->
+            <div>
+              {{ t.appearance_count(record.talks.length) }}
+            </div>
+            <!-- 登壇年度のリスト（各年度ページへのリンク） -->
+            <div class="mt-2 text-[12px] text-ink-2">
+              {{ t.years_appeared }}:
+              <span v-for="(year, index) in record.years" :key="year">
+                <template v-if="index > 0">
+                  ,
+                </template>
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${year}`">
+                  {{ year }}
+                </a>
+                <!-- @vize:ignore-end -->
               </span>
             </div>
-          </li>
-        </ul>
-      </section>
-    </template>
-    <!-- スピーカーが存在しない場合 -->
-    <main v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
-      <h1 class="font-display text-[40px] text-ink m-0">
-        Speaker Not Found
-      </h1>
-      <p>
-        {{ speakerName }}
-      </p>
+          </div>
+        </header>
+        <!-- 関連トーク一覧セクション -->
+        <section class="px-pad-x py-10">
+          <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
+            {{ t.related_talks }}
+          </h2>
+          <ul class="list-none p-0 m-0">
+            <li
+              v-for="talk in record.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <span class="font-mono text-[12px] text-center pt-[3px]">
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
+                  {{ talk.year }}
+                </a>
+                <!-- @vize:ignore-end -->
+              </span>
+              <div class="flex flex-col gap-y-2">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span>
+                    <span
+                      class="group-hover:underline"
+                      :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
+                    >
+                      {{ talk.title || t.tbd }}
+                    </span>
+                    <span class="text-[10px] ml-1">
+                      ({{ t.external }})
+                    </span>
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span
+                    v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
+                    :key="coSpeakerName"
+                    class="contents"
+                  >
+                    <template v-if="coSpeakerIndex > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink underline hover:no-underline"
+                      :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
+                    >
+                      {{ coSpeakerName }}
+                    </a>
+                    <!-- @vize:ignore-end -->
+                  </span>
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </template>
+      <!-- スピーカーが存在しない場合 -->
+      <div v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
+        <h1 class="font-display text-[40px] text-ink m-0">
+          Speaker Not Found
+        </h1>
+        <p>
+          {{ speakerName }}
+        </p>
+      </div>
     </main>
     <AppFooter />
   </div>

--- a/src/islands/YearPageIsland.vue
+++ b/src/islands/YearPageIsland.vue
@@ -17,7 +17,7 @@ const { t, lang } = useVfjsI18n();
   <div>
     <AppHeader />
     <!-- 年度ページのメインコンテンツ -->
-    <main>
+    <main id="main" tabindex="-1">
       <template v-if="found">
         <!-- 年度ページのヘッダー（タイトル・トーク数・公式サイトリンク） -->
         <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">

--- a/src/routes/NotFoundRoute.vue
+++ b/src/routes/NotFoundRoute.vue
@@ -9,7 +9,11 @@ const { t } = useVfjsI18n();
 <template>
   <div>
     <AppHeader />
-    <main class="min-h-[60vh] px-pad-x py-[clamp(64px,10vw,140px)] border-b border-rule">
+    <main
+      id="main"
+      class="min-h-[60vh] px-pad-x py-[clamp(64px,10vw,140px)] border-b border-rule"
+      tabindex="-1"
+    >
       <p class="font-mono text-[12px] tracking-[0.12em] uppercase text-ink-3 mb-4.5">
         404
       </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #836
Closes #837
Closes #838
Closes #839
Closes #840
Closes #841
Closes #842
Closes #843
Closes #844
Closes #845
Closes #846

2026-09-03 の a11y レビューで上がった Major 10件をまとめて直しています。

## 変更内容

- **#837** Chronicle の年を `h2` にし、装飾数字だけを隠さない
- **#838** Directory に「スピーカー一覧（件数・ソート）」見出しを置き、`ol` と `aria-labelledby` で紐付け
- **#839** 表示切替を APG Tabs に（`aria-controls` / `tabpanel` / 非選択 `tabindex="-1"` / 矢印・Home/End）
- **#840** 年度フィルタに `aria-pressed` と「選択中」
- **#841** Directory ソートを日本語ラベル + `aria-pressed`
- **#842** 「本文へ」「フッターへ」スキップリンク。Chronicle には年度目次
- **#843** ダーク `--ink-3` を `#888880` に（paper 比 約 4.78:1）
- **#844** `html { scroll-padding-top: 72px }` で sticky header 下にフォーカスが隠れないようにする
- **#845** Directory 行ボタンを短い `aria-label` に集約し、年度グリッドは `aria-hidden`。回数バッジは実テキスト。`aria-controls` 付き
- **#846** 件数・空状態を `role="status"` / `aria-live="polite"` で通知

## #860 からの統合

同課題に対する #860 の設計上の利点を本PRに取り込みました（#860 / #861 / #862 は本PRに集約のためクローズ）。

- `main#main` ランドマークを `HomePageIsland` が単一所有し、`ChronicleView` / `DirectoryView` は `section` を返すように変更（ビュー切替をまたいでランドマークが安定し、`main#main` の二重宣言も解消）。あわせてフォーカス可能要素を含む tabpanel の冗長な `tabindex="0"` を削除
- スキップリンクをスロット付きの `SkipLinks.vue` コンポーネントに切り出し（`AppHeader` から利用、テスト付き）
- `YearFilterBar` の `role="group"` を可視ラベルへの `aria-labelledby` に変更し、`region` の `aria-label` との重複を解消

## 確認

- `vp run lint`
- `vp run format:check`
- `vp run typecheck`
- `vp test run`（12 files / 33 tests passed）
- dev サーバの SSR 出力で `/`・`/2024` の `main#main` が1つで tabpanel を内包し、スキップリンクが全ページに描画されることを確認
- ブラウザ: スキップリンク、年度目次ジャンプ、Directory 見出し/ソート、行の開閉、空状態のライブリージョン、ダークの非選択タブ、モバイル折返し
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4f7353-5c3b-4809-a036-4212a9d787ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4f7353-5c3b-4809-a036-4212a9d787ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

