### PR TITLE
fix(a11y): Major アクセシビリティ課題を解消する (#836)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -26,7 +26,7 @@
     --rule-softer: rgba(232, 228, 220, 0.07);
     --ink: #e8e4dc;
     --ink-2: #b4b0a8;
-    --ink-3: #7a7a72;
+    --ink-3: #8a8a82;
     --accent: #2ed9a8;
     --accent-ink: #0d2820;
   }
@@ -40,7 +40,7 @@
   --rule-softer: rgba(232, 228, 220, 0.07);
   --ink: #e8e4dc;
   --ink-2: #b4b0a8;
-  --ink-3: #7a7a72;
+  --ink-3: #8a8a82;
   --accent: #2ed9a8;
   --accent-ink: #0d2820;
 }
@@ -79,6 +79,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-padding-top: 72px;
+}
+
 html,
 body {
   margin: 0;
@@ -112,4 +116,36 @@ input:focus-visible {
 }
 select {
   appearance: base-select;
+}
+
+.skip-nav {
+  position: absolute;
+  left: var(--pad-x);
+  top: 8px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  transform: translateY(-160%);
+}
+
+.skip-nav:focus-within {
+  transform: none;
+}
+
+.skip-link {
+  display: inline-block;
+  padding: 8px 14px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+}
+
+.skip-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -5,7 +5,10 @@ const { t } = useVfjsI18n();
 </script>
 
 <template>
-  <footer class="border-t border-rule flex flex-wrap gap-x-6 gap-y-2 items-baseline justify-between px-pad-x py-5 text-[12px] font-mono">
+  <footer
+    id="site-footer"
+    class="border-t border-rule flex flex-wrap gap-x-6 gap-y-2 items-baseline justify-between px-pad-x py-5 text-[12px] font-mono"
+  >
     <!-- トップページへ戻るリンク -->
     <div>
       <a class="text-inherit underline hover:no-underline hover:text-ink" href="/">

--- a/src/components/ChronicleView.test.ts
+++ b/src/components/ChronicleView.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakers } from "../../musea/sample-data";
+import ChronicleView from "./ChronicleView.vue";
+
+describe("ChronicleView", () => {
+  it("各年を見出しにしてライブリージョンで件数を伝える", () => {
+    const wrapper = mount(ChronicleView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        selectedYear: "all",
+        selectedSpeaker: "all",
+        query: "",
+      },
+    });
+
+    const yearHeadings = wrapper.findAll("h2").map((heading) => heading.text());
+    expect(yearHeadings).toContain("2018");
+    expect(yearHeadings).toContain("2025");
+    expect(wrapper.find("h2[aria-hidden]").exists()).toBe(false);
+
+    const status = wrapper.get('[role="status"]');
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(status.attributes("aria-atomic")).toBe("true");
+    expect(status.text()).toContain("5件中5件を表示");
+  });
+
+  it("該当なしのとき同じライブリージョンで空状態を伝える", async () => {
+    const wrapper = mount(ChronicleView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        selectedYear: "all",
+        selectedSpeaker: "all",
+        query: "not-found",
+      },
+    });
+
+    const status = wrapper.get('[role="status"]');
+    expect(status.text()).toContain("5件中0件を表示");
+    expect(status.text()).toContain("該当するスピーカーが見つかりません。");
+    expect(wrapper.find("#year-list").exists()).toBe(true);
+  });
+});

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -106,113 +106,115 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       {{ t.empty }}
     </div>
     <!-- 年度グループリスト -->
-    <ol id="year-list" class="list-none p-0 m-0" :aria-label="t.nav_all_label">
-      <!-- 各年度グループ -->
-      <li
-        v-for="[year, arr] in grouped"
-        :key="year"
-        class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
-      >
-        <!-- 年度ラベル（スクロール時に上部に固定） -->
-        <div
-          class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
-          :id="`year-${year}`"
+    <div id="year-list">
+      <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
+        <!-- 各年度グループ -->
+        <li
+          v-for="[year, arr] in grouped"
+          :key="year"
+          class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
         >
-          <!-- 年度見出し -->
-          <h2 class="m-0 font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
-            {{ year }}
-          </h2>
-          <!-- その年のトーク総数 -->
-          <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
-            {{ t.year_total_talks(arr.length) }}
-          </span>
-          <!-- 年度別ページへの矢印リンク -->
-          <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
-          <!-- @vize:ignore-start -->
-          <a
-            class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-            :aria-label="`${year} speakers`"
-            :href="`/${year}`"
+          <!-- 年度ラベル（スクロール時に上部に固定） -->
+          <div
+            class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
+            :id="`year-${year}`"
           >
-            →
-          </a>
-          <!-- @vize:ignore-end -->
-        </div>
-        <!-- その年のスピーカー行リスト -->
-        <ol class="list-none p-0 m-0 border-t border-rule-soft">
-          <!-- 各スピーカー行 -->
-          <li
-            v-for="(s, i) in arr"
-            :key="`${year}-${i}`"
-            class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
-          >
-            <!-- 行番号（表示専用） -->
-            <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
-              <span>
-                {{ String(i + 1).padStart(2, "0") }}
-              </span>
-            </div>
-            <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
-              <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
-              <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
-                <span v-for="(n, ni) in s.name" :key="n" class="contents">
-                  <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
-                    ×
+            <!-- 年度見出し -->
+            <h2 class="m-0 font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
+              {{ year }}
+            </h2>
+            <!-- その年のトーク総数 -->
+            <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
+              {{ t.year_total_talks(arr.length) }}
+            </span>
+            <!-- 年度別ページへの矢印リンク -->
+            <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+            <!-- @vize:ignore-start -->
+            <a
+              class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
+              :aria-label="`${year} speakers`"
+              :href="`/${year}`"
+            >
+              →
+            </a>
+            <!-- @vize:ignore-end -->
+          </div>
+          <!-- その年のスピーカー行リスト -->
+          <ol class="list-none p-0 m-0 border-t border-rule-soft">
+            <!-- 各スピーカー行 -->
+            <li
+              v-for="(s, i) in arr"
+              :key="`${year}-${i}`"
+              class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
+            >
+              <!-- 行番号（表示専用） -->
+              <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
+                <span>
+                  {{ String(i + 1).padStart(2, "0") }}
+                </span>
+              </div>
+              <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
+                <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
+                <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
+                  <span v-for="(n, ni) in s.name" :key="n" class="contents">
+                    <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
+                      ×
+                    </span>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
+                      :href="`/speakers/${encodeURIComponent(n)}`"
+                    >
+                      <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
+                        {{ n }}
+                        <rt>
+                          {{ s.nameRuby[ni] }}
+                        </rt>
+                      </ruby>
+                      <span v-else>
+                        {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
+                      </span>
+                    </a>
+                    <!-- @vize:ignore-end -->
                   </span>
-                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                </div>
+                <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
+                <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
+                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
                   <!-- @vize:ignore-start -->
                   <a
-                    class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
-                    :href="`/speakers/${encodeURIComponent(n)}`"
+                    v-if="s.title"
+                    class="text-ink-2 no-underline group hover:text-ink"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    :href="s.url"
                   >
-                    <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
-                      {{ n }}
-                      <rt>
-                        {{ s.nameRuby[ni] }}
-                      </rt>
-                    </ruby>
-                    <span v-else>
-                      {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
+                    <!-- パネルセッションのフォーマットバッジ -->
+                    <span
+                      v-if='s.format === "panel"'
+                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                    >
+                      {{ t.session_format_panel }}
+                    </span>
+                    <span class="group-hover:underline">
+                      {{ s.title }}
+                    </span>
+                    <span class="font-mono text-[10px] text-ink-2 ml-1">
+                      ({{ t.external }})
                     </span>
                   </a>
                   <!-- @vize:ignore-end -->
-                </span>
+                  <!-- タイトル未決定時のプレースホルダー -->
+                  <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
+                    {{ t.tbd }}
+                  </span>
+                </div>
               </div>
-              <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
-              <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
-                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-                <!-- @vize:ignore-start -->
-                <a
-                  v-if="s.title"
-                  class="text-ink-2 no-underline group hover:text-ink"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  :href="s.url"
-                >
-                  <!-- パネルセッションのフォーマットバッジ -->
-                  <span
-                    v-if='s.format === "panel"'
-                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
-                  >
-                    {{ t.session_format_panel }}
-                  </span>
-                  <span class="group-hover:underline">
-                    {{ s.title }}
-                  </span>
-                  <span class="font-mono text-[10px] text-ink-2 ml-1">
-                    ({{ t.external }})
-                  </span>
-                </a>
-                <!-- @vize:ignore-end -->
-                <!-- タイトル未決定時のプレースホルダー -->
-                <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
-                  {{ t.tbd }}
-                </span>
-              </div>
-            </div>
-          </li>
-        </ol>
-      </li>
-    </ol>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </div>
   </section>
 </template>

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -74,137 +74,145 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 </script>
 
 <template>
-  <main>
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- フィルター結果が0件のとき -->
-      <div
-        v-if="grouped.length === 0"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
-      >
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- 検索・フィルタ結果のライブリージョン -->
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="px-pad-x py-3 border-b border-rule-soft font-mono text-[12px] tracking-[0.06em] text-ink-2"
+      role="status"
+    >
+      {{ t.result_count(filtered.length, allSpeakers.length) }}
+      <span v-if="grouped.length === 0">
         {{ t.empty }}
-      </div>
-      <!-- 年度グループリスト -->
-      <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
-        <!-- 各年度グループ -->
-        <li
-          v-for="[year, arr] in grouped"
-          :key="year"
-          class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
+      </span>
+    </div>
+    <!-- フィルター結果が0件のとき（ライブリージョンと重複しないよう表示専用） -->
+    <div
+      v-if="grouped.length === 0"
+      aria-hidden="true"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- 年度グループリスト -->
+    <ol id="year-list" class="list-none p-0 m-0" :aria-label="t.nav_all_label">
+      <!-- 各年度グループ -->
+      <li
+        v-for="[year, arr] in grouped"
+        :key="year"
+        class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
+      >
+        <!-- 年度ラベル（スクロール時に上部に固定） -->
+        <div
+          class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
+          :id="`year-${year}`"
         >
-          <!-- 年度ラベル（スクロール時に上部に固定） -->
-          <div
-            class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
-            :id="`year-${year}`"
+          <!-- 年度見出し -->
+          <h2 class="m-0 font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
+            {{ year }}
+          </h2>
+          <!-- その年のトーク総数 -->
+          <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
+            {{ t.year_total_talks(arr.length) }}
+          </span>
+          <!-- 年度別ページへの矢印リンク -->
+          <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
+            :aria-label="`${year} speakers`"
+            :href="`/${year}`"
           >
-            <!-- 年度テキスト（表示専用） -->
-            <span
-              aria-hidden="true"
-              class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink"
-            >
-              {{ year }}
-            </span>
-            <!-- その年のトーク総数 -->
-            <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
-              {{ t.year_total_talks(arr.length) }}
-            </span>
-            <!-- 年度別ページへの矢印リンク -->
-            <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-              :aria-label="`${year} speakers`"
-              :href="`/${year}`"
-            >
-              →
-            </a>
-            <!-- @vize:ignore-end -->
-          </div>
-          <!-- その年のスピーカー行リスト -->
-          <ol class="list-none p-0 m-0 border-t border-rule-soft">
-            <!-- 各スピーカー行 -->
-            <li
-              v-for="(s, i) in arr"
-              :key="`${year}-${i}`"
-              class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
-            >
-              <!-- 行番号（表示専用） -->
-              <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
-                <span>
-                  {{ String(i + 1).padStart(2, "0") }}
-                </span>
-              </div>
-              <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
-                <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
-                <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
-                  <span v-for="(n, ni) in s.name" :key="n" class="contents">
-                    <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
-                      ×
-                    </span>
-                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                    <!-- @vize:ignore-start -->
-                    <a
-                      class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
-                      :href="`/speakers/${encodeURIComponent(n)}`"
-                    >
-                      <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
-                        {{ n }}
-                        <rt>
-                          {{ s.nameRuby[ni] }}
-                        </rt>
-                      </ruby>
-                      <span v-else>
-                        {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
-                      </span>
-                    </a>
-                    <!-- @vize:ignore-end -->
+            →
+          </a>
+          <!-- @vize:ignore-end -->
+        </div>
+        <!-- その年のスピーカー行リスト -->
+        <ol class="list-none p-0 m-0 border-t border-rule-soft">
+          <!-- 各スピーカー行 -->
+          <li
+            v-for="(s, i) in arr"
+            :key="`${year}-${i}`"
+            class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
+          >
+            <!-- 行番号（表示専用） -->
+            <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
+              <span>
+                {{ String(i + 1).padStart(2, "0") }}
+              </span>
+            </div>
+            <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
+              <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
+              <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
+                <span v-for="(n, ni) in s.name" :key="n" class="contents">
+                  <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
+                    ×
                   </span>
-                </div>
-                <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
-                <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
                   <!-- @vize:ignore-start -->
                   <a
-                    v-if="s.title"
-                    class="text-ink-2 no-underline group hover:text-ink"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="s.url"
+                    class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
+                    :href="`/speakers/${encodeURIComponent(n)}`"
                   >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='s.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
-                    >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ s.title }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
+                    <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
+                      {{ n }}
+                      <rt>
+                        {{ s.nameRuby[ni] }}
+                      </rt>
+                    </ruby>
+                    <span v-else>
+                      {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
                     </span>
                   </a>
                   <!-- @vize:ignore-end -->
-                  <!-- タイトル未決定時のプレースホルダー -->
-                  <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
-                    {{ t.tbd }}
-                  </span>
-                </div>
+                </span>
               </div>
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </section>
-  </main>
+              <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
+              <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  v-if="s.title"
+                  class="text-ink-2 no-underline group hover:text-ink"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="s.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='s.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ s.title }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- タイトル未決定時のプレースホルダー -->
+                <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
+                  {{ t.tbd }}
+                </span>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/DirectoryView.test.ts
+++ b/src/components/DirectoryView.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakers } from "../../musea/sample-data";
+import DirectoryView from "./DirectoryView.vue";
+
+describe("DirectoryView", () => {
+  it("一覧見出しとソート状態をプログラム的に伝える", () => {
+    const wrapper = mount(DirectoryView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        selectedYear: "all",
+        selectedSpeaker: "all",
+        query: "",
+      },
+    });
+
+    const heading = wrapper.get("#directory-heading");
+    expect(heading.element.tagName).toBe("H2");
+    expect(heading.text()).toContain("スピーカー一覧");
+    expect(heading.text()).toContain("登壇回数の多い順");
+    expect(wrapper.get("#directory-list").attributes("aria-labelledby")).toBe("directory-heading");
+
+    const sortButtons = wrapper.findAll('[aria-label="並び替え"] button');
+    expect(sortButtons[0]?.attributes("aria-pressed")).toBe("true");
+    expect(sortButtons[1]?.attributes("aria-pressed")).toBe("false");
+    expect(sortButtons[0]?.text()).toContain("登壇回数の多い順");
+  });
+
+  it("行ボタンの名前に年度グリッドを含めず aria-controls を付ける", async () => {
+    const wrapper = mount(DirectoryView, {
+      attachTo: document.body,
+      props: {
+        allSpeakers: museaSpeakers,
+        selectedYear: "all",
+        selectedSpeaker: "all",
+        query: "",
+      },
+    });
+
+    const row = wrapper
+      .findAll("button[aria-expanded]")
+      .find((button) => (button.attributes("aria-label") ?? "").includes("Evan You"));
+    expect(row).toBeTruthy();
+    expect(row!.attributes("aria-label")).toBe("Evan You、2回登壇、詳細を開く");
+    expect(row!.attributes("aria-label")).not.toMatch(/\b18\b/);
+    expect(row!.attributes("aria-controls")).toBe(
+      `speaker-panel-${encodeURIComponent("Evan You")}`,
+    );
+
+    await row!.trigger("click");
+    expect(row!.attributes("aria-expanded")).toBe("true");
+    expect(row!.attributes("aria-label")).toBe("Evan You、2回登壇、詳細を閉じる");
+    expect(wrapper.find(`#${CSS.escape(row!.attributes("aria-controls")!)}`).exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("件数をライブリージョンの完全文で伝える", () => {
+    const wrapper = mount(DirectoryView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        selectedYear: "all",
+        selectedSpeaker: "all",
+        query: "not-found",
+      },
+    });
+
+    const status = wrapper.get('[role="status"]');
+    expect(status.attributes("aria-live")).toBe("polite");
+    expect(status.text()).toContain("4件中0件を表示");
+    expect(status.text()).toContain("該当するスピーカーが見つかりません。");
+  });
+});

--- a/src/components/DirectoryView.test.ts
+++ b/src/components/DirectoryView.test.ts
@@ -14,11 +14,12 @@ describe("DirectoryView", () => {
       },
     });
 
-    const heading = wrapper.get("#directory-heading");
-    expect(heading.element.tagName).toBe("H2");
+    const heading = wrapper.get("h2");
     expect(heading.text()).toContain("スピーカー一覧");
     expect(heading.text()).toContain("登壇回数の多い順");
-    expect(wrapper.get("#directory-list").attributes("aria-labelledby")).toBe("directory-heading");
+    expect(wrapper.get("#directory-list ol").attributes("aria-labelledby")).toBe(
+      heading.attributes("id"),
+    );
 
     const sortButtons = wrapper.findAll('[aria-label="並び替え"] button');
     expect(sortButtons[0]?.attributes("aria-pressed")).toBe("true");

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, useId } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
@@ -45,6 +45,8 @@ const sortLabel = computed(() => {
 function displayName(rec: SpeakerRecord) {
   return lang.value === "en" && rec.nameEn ? rec.nameEn : rec.name;
 }
+
+const directoryHeadingId = useId();
 
 function speakerPanelId(name: string) {
   return `speaker-panel-${encodeURIComponent(name)}`;
@@ -141,8 +143,8 @@ function updateSelectedYear(value: AcceptedYear | "all") {
     <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
     <!-- スピーカー一覧の見出し（件数とソート状態を含む） -->
     <h2
-      id="directory-heading"
       class="px-pad-x pt-5 pb-1 font-display text-[18px] font-[500] tracking-[-0.01em] text-ink"
+      :id="directoryHeadingId"
     >
       {{ t.directory_heading(filtered.length, sortLabel) }}
     </h2>
@@ -219,164 +221,166 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       {{ t.empty }}
     </div>
     <!-- スピーカー一覧リスト -->
-    <ol id="directory-list" aria-labelledby="directory-heading" class="list-none p-0 m-0">
-      <li
-        v-for="(rec, i) in filtered"
-        :key="rec.name"
-        class="border-b border-rule-softer"
-        :data-open='openRows.has(rec.name) ? "true" : "false"'
-      >
-        <!-- スピーカー行の展開/折りたたみボタン -->
-        <button
-          class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
-          type="button"
-          :aria-expanded="openRows.has(rec.name)"
-          :aria-controls="speakerPanelId(rec.name)"
-          :aria-label="t.directory_row_label(displayName(rec), rec.talks.length, openRows.has(rec.name))"
-          :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
-          @click="() => toggleRow(rec.name)"
+    <div id="directory-list">
+      <ol class="list-none p-0 m-0" :aria-labelledby="directoryHeadingId">
+        <li
+          v-for="(rec, i) in filtered"
+          :key="rec.name"
+          class="border-b border-rule-softer"
+          :data-open='openRows.has(rec.name) ? "true" : "false"'
         >
-          <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
-            <!-- 行番号（表示専用） -->
-            <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
-              {{ String(i + 1).padStart(3, "0") }}
-            </span>
-            <!-- スピーカー名（振り仮名・英語名対応） -->
-            <span
-              class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
-              :lang='hasJapanese(rec.name) ? "ja" : "en"'
-            >
-              <ruby v-if='rec.nameRuby && lang === "ja"'>
-                {{ rec.name }}
-                <rt>
-                  {{ rec.nameRuby }}
-                </rt>
-              </ruby>
-              <template v-else>
-                {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-              </template>
-              <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示） -->
+          <!-- スピーカー行の展開/折りたたみボタン -->
+          <button
+            class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
+            type="button"
+            :aria-expanded="openRows.has(rec.name)"
+            :aria-controls="speakerPanelId(rec.name)"
+            :aria-label="t.directory_row_label(displayName(rec), rec.talks.length, openRows.has(rec.name))"
+            :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
+            @click="() => toggleRow(rec.name)"
+          >
+            <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
+              <!-- 行番号（表示専用） -->
+              <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
+                {{ String(i + 1).padStart(3, "0") }}
+              </span>
+              <!-- スピーカー名（振り仮名・英語名対応） -->
               <span
-                v-if="rec.talks.length > 1"
-                aria-hidden="true"
-                class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
+                class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
+                :lang='hasJapanese(rec.name) ? "ja" : "en"'
               >
-                ×{{ rec.talks.length }}
+                <ruby v-if='rec.nameRuby && lang === "ja"'>
+                  {{ rec.name }}
+                  <rt>
+                    {{ rec.nameRuby }}
+                  </rt>
+                </ruby>
+                <template v-else>
+                  {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+                </template>
+                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示） -->
+                <span
+                  v-if="rec.talks.length > 1"
+                  aria-hidden="true"
+                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
+                >
+                  ×{{ rec.talks.length }}
+                </span>
+              </span>
+              <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化。名前は行ボタンの aria-label に集約） -->
+              <span
+                aria-hidden="true"
+                class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
+              >
+                <span
+                  v-for="y in YEARS"
+                  :key="y"
+                  class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
+                  :class='[
+                    rec.years.includes(y) && selectedYear === y
+                      ? "bg-accent border border-accent text-accent-ink"
+                      : rec.years.includes(y)
+                        ? "bg-ink border border-ink text-paper"
+                        : "border border-ink text-ink",
+                  ]'
+                  :title="y"
+                >
+                  {{ y.slice(-2) }}
+                </span>
               </span>
             </span>
-            <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化。名前は行ボタンの aria-label に集約） -->
+            <!-- 展開/折りたたみアイコン（+/−） -->
             <span
               aria-hidden="true"
-              class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
+              class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
             >
-              <span
-                v-for="y in YEARS"
-                :key="y"
-                class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
-                :class='[
-                  rec.years.includes(y) && selectedYear === y
-                    ? "bg-accent border border-accent text-accent-ink"
-                    : rec.years.includes(y)
-                      ? "bg-ink border border-ink text-paper"
-                      : "border border-ink text-ink",
-                ]'
-                :title="y"
-              >
-                {{ y.slice(-2) }}
-              </span>
+              {{ openRows.has(rec.name) ? "−" : "+" }}
             </span>
-          </span>
-          <!-- 展開/折りたたみアイコン（+/−） -->
-          <span
-            aria-hidden="true"
-            class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+          </button>
+          <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
+          <div
+            v-if="openRows.has(rec.name)"
+            :id="speakerPanelId(rec.name)"
+            class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
           >
-            {{ openRows.has(rec.name) ? "−" : "+" }}
-          </span>
-        </button>
-        <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
-        <div
-          v-if="openRows.has(rec.name)"
-          :id="speakerPanelId(rec.name)"
-          class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
-        >
-          <!-- スピーカープロフィールページへのリンク -->
-          <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-          <!-- @vize:ignore-start -->
-          <a
-            class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
-            :href="`/speakers/${encodeURIComponent(rec.name)}`"
-          >
-            {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-          </a>
-          <!-- @vize:ignore-end -->
-          <!-- 登壇一覧リスト -->
-          <ol class="list-none p-0 m-0 mt-[14px]">
-            <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
-            <li
-              v-for="(talk, k) in rec.talks"
-              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-              class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
-              :class='k === 0 ? "border-t-0" : ""'
+            <!-- スピーカープロフィールページへのリンク -->
+            <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+            <!-- @vize:ignore-start -->
+            <a
+              class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
+              :href="`/speakers/${encodeURIComponent(rec.name)}`"
             >
-              <!-- 開催年リンク（年度別ページへ） -->
-              <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
-              <!-- @vize:ignore-start -->
-              <a
-                class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
-                :href="`/${talk.year}`"
+              {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+            </a>
+            <!-- @vize:ignore-end -->
+            <!-- 登壇一覧リスト -->
+            <ol class="list-none p-0 m-0 mt-[14px]">
+              <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
+              <li
+                v-for="(talk, k) in rec.talks"
+                :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+                class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
+                :class='k === 0 ? "border-t-0" : ""'
               >
-                {{ talk.year }}
-              </a>
-              <!-- @vize:ignore-end -->
-              <div class="flex flex-col gap-y-[8px]">
-                <!-- トークタイトル（外部リンク） -->
-                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- 開催年リンク（年度別ページへ） -->
+                <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
                 <!-- @vize:ignore-start -->
                 <a
-                  class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  :href="talk.url"
+                  class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
+                  :href="`/${talk.year}`"
                 >
-                  <!-- パネルセッションのフォーマットバッジ -->
-                  <span
-                    v-if='talk.format === "panel"'
-                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
-                  >
-                    {{ t.session_format_panel }}
-                  </span>
-                  <span class="group-hover:underline">
-                    {{ talk.title || t.tbd }}
-                  </span>
-                  <span class="font-mono text-[10px] text-ink-2 ml-1">
-                    ({{ t.external }})
-                  </span>
+                  {{ talk.year }}
                 </a>
                 <!-- @vize:ignore-end -->
-                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                  w/
-                  <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
-                    <template v-if="ci > 0">
-                      ,
-                    </template>
-                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                    <!-- @vize:ignore-start -->
-                    <a
-                      class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
-                      :href="`/speakers/${encodeURIComponent(cn)}`"
+                <div class="flex flex-col gap-y-[8px]">
+                  <!-- トークタイトル（外部リンク） -->
+                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                  <!-- @vize:ignore-start -->
+                  <a
+                    class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    :href="talk.url"
+                  >
+                    <!-- パネルセッションのフォーマットバッジ -->
+                    <span
+                      v-if='talk.format === "panel"'
+                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
                     >
-                      {{ cn }}
-                    </a>
-                    <!-- @vize:ignore-end -->
+                      {{ t.session_format_panel }}
+                    </span>
+                    <span class="group-hover:underline">
+                      {{ talk.title || t.tbd }}
+                    </span>
+                    <span class="font-mono text-[10px] text-ink-2 ml-1">
+                      ({{ t.external }})
+                    </span>
+                  </a>
+                  <!-- @vize:ignore-end -->
+                  <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                  <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                    w/
+                    <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
+                      <template v-if="ci > 0">
+                        ,
+                      </template>
+                      <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                      <!-- @vize:ignore-start -->
+                      <a
+                        class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
+                        :href="`/speakers/${encodeURIComponent(cn)}`"
+                      >
+                        {{ cn }}
+                      </a>
+                      <!-- @vize:ignore-end -->
+                    </span>
                   </span>
-                </span>
-              </div>
-            </li>
-          </ol>
-        </div>
-      </li>
-    </ol>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </li>
+      </ol>
+    </div>
   </section>
 </template>

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -35,6 +35,21 @@ const speakerOptions = computed(() =>
 
 const sort = ref<"name-asc" | "name-desc" | "appearances" | "latest">("appearances");
 
+const sortLabel = computed(() => {
+  if (sort.value === "appearances") return t.value.sort_appearances;
+  if (sort.value === "name-desc") return t.value.sort_name_desc;
+  if (sort.value === "name-asc") return t.value.sort_name_asc;
+  return t.value.sort_latest;
+});
+
+function displayName(rec: SpeakerRecord) {
+  return lang.value === "en" && rec.nameEn ? rec.nameEn : rec.name;
+}
+
+function speakerPanelId(name: string) {
+  return `speaker-panel-${encodeURIComponent(name)}`;
+}
+
 const counts = computed(() => {
   const c: Record<string, number> = { all: allRecords.value.length };
   for (const y of YEARS) {
@@ -113,223 +128,255 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 
 <template>
   <!-- ディレクトリビュー：スピーカーを人物単位でまとめ、アコーディオンで登壇履歴を表示するビュー -->
-  <main>
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- Sort header -->
-      <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
-      <div class="flex items-center gap-2 px-pad-x pt-4.5 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
-        <!-- 登壇回数の多い順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "appearances"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByAppearances"
-        >
-          Appearances ↓
-        </button>
-        <!-- 名前の昇順/降順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "name-asc" || sort === "name-desc"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="toggleNameSort"
-        >
-          Name {{ sort === "name-desc" ? "Z→A" : "A→Z" }}
-        </button>
-        <!-- 最新登壇年の新しい順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "latest"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByLatest"
-        >
-          Latest year ↓
-        </button>
-        <!-- フィルター済み件数 / 全体件数の表示 -->
-        <span class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap">
-          {{ String(filtered.length).padStart(3, "0") }} /
-          {{ String(allRecords.length).padStart(3, "0") }}
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- スピーカー一覧の見出し（件数とソート状態を含む） -->
+    <h2
+      id="directory-heading"
+      class="px-pad-x pt-5 pb-1 font-display text-[18px] font-[500] tracking-[-0.01em] text-ink"
+    >
+      {{ t.directory_heading(filtered.length, sortLabel) }}
+    </h2>
+    <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
+    <div
+      class="flex items-center gap-2 px-pad-x pt-2 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto"
+      role="group"
+      :aria-label="t.sort_label"
+    >
+      <!-- 登壇回数の多い順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.04em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "appearances" ? "true" : "false"'
+        :class='sort === "appearances"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="sortByAppearances"
+      >
+        {{ t.sort_appearances }}
+        <span v-if='sort === "appearances"' class="sr-only">
+          {{ t.selected }}
+        </span>
+      </button>
+      <!-- 名前の昇順/降順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.04em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "name-asc" || sort === "name-desc" ? "true" : "false"'
+        :class='sort === "name-asc" || sort === "name-desc"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="toggleNameSort"
+      >
+        {{ sort === "name-desc" ? t.sort_name_desc : t.sort_name_asc }}
+        <span v-if='sort === "name-asc" || sort === "name-desc"' class="sr-only">
+          {{ t.selected }}
+        </span>
+      </button>
+      <!-- 最新登壇年の新しい順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.04em] px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "latest" ? "true" : "false"'
+        :class='sort === "latest"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="sortByLatest"
+      >
+        {{ t.sort_latest }}
+        <span v-if='sort === "latest"' class="sr-only">
+          {{ t.selected }}
+        </span>
+      </button>
+      <!-- 検索・フィルタ結果のライブリージョン -->
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap"
+        role="status"
+      >
+        {{ t.result_count(filtered.length, allRecords.length) }}
+        <span v-if="filtered.length === 0">
+          {{ t.empty }}
         </span>
       </div>
-      <!-- フィルター結果が0件のときの空状態メッセージ -->
-      <div
-        v-if="filtered.length === 0"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    </div>
+    <!-- フィルター結果が0件のときの空状態メッセージ（ライブリージョンと重複しないよう表示専用） -->
+    <div
+      v-if="filtered.length === 0"
+      aria-hidden="true"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- スピーカー一覧リスト -->
+    <ol id="directory-list" aria-labelledby="directory-heading" class="list-none p-0 m-0">
+      <li
+        v-for="(rec, i) in filtered"
+        :key="rec.name"
+        class="border-b border-rule-softer"
+        :data-open='openRows.has(rec.name) ? "true" : "false"'
       >
-        {{ t.empty }}
-      </div>
-      <!-- スピーカー一覧リスト -->
-      <ol class="list-none p-0 m-0">
-        <li
-          v-for="(rec, i) in filtered"
-          :key="rec.name"
-          class="border-b border-rule-softer"
-          :data-open='openRows.has(rec.name) ? "true" : "false"'
+        <!-- スピーカー行の展開/折りたたみボタン -->
+        <button
+          class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
+          type="button"
+          :aria-expanded="openRows.has(rec.name)"
+          :aria-controls="speakerPanelId(rec.name)"
+          :aria-label="t.directory_row_label(displayName(rec), rec.talks.length, openRows.has(rec.name))"
+          :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
+          @click="() => toggleRow(rec.name)"
         >
-          <!-- スピーカー行の展開/折りたたみボタン -->
-          <button
-            class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
-            type="button"
-            :aria-expanded="openRows.has(rec.name)"
-            :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
-            @click="() => toggleRow(rec.name)"
-          >
-            <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
-              <!-- 行番号（表示専用） -->
-              <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
-                {{ String(i + 1).padStart(3, "0") }}
-              </span>
-              <!-- スピーカー名（振り仮名・英語名対応） -->
+          <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
+            <!-- 行番号（表示専用） -->
+            <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
+              {{ String(i + 1).padStart(3, "0") }}
+            </span>
+            <!-- スピーカー名（振り仮名・英語名対応） -->
+            <span
+              class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
+              :lang='hasJapanese(rec.name) ? "ja" : "en"'
+            >
+              <ruby v-if='rec.nameRuby && lang === "ja"'>
+                {{ rec.name }}
+                <rt>
+                  {{ rec.nameRuby }}
+                </rt>
+              </ruby>
+              <template v-else>
+                {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+              </template>
+              <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示） -->
               <span
-                class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
-                :lang='hasJapanese(rec.name) ? "ja" : "en"'
+                v-if="rec.talks.length > 1"
+                aria-hidden="true"
+                class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
               >
-                <ruby v-if='rec.nameRuby && lang === "ja"'>
-                  {{ rec.name }}
-                  <rt>
-                    {{ rec.nameRuby }}
-                  </rt>
-                </ruby>
-                <template v-else>
-                  {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-                </template>
-                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示。formatter の改行空白を避けるため data-count で描画） -->
-                <span
-                  v-if="rec.talks.length > 1"
-                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px] after:content-[attr(data-count)]"
-                  :aria-label="t.appearance_count(rec.talks.length)"
-                  :data-count="`×${rec.talks.length}`"
-                ></span>
-              </span>
-              <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
-              <span
-                class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
-                :aria-label='t.years_appeared + ": " + rec.years.join(", ")'
-              >
-                <span
-                  v-for="y in YEARS"
-                  :key="y"
-                  class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
-                  :class='[
-                    rec.years.includes(y) && selectedYear === y
-                      ? "bg-accent border border-accent text-accent-ink"
-                      : rec.years.includes(y)
-                        ? "bg-ink border border-ink text-paper"
-                        : "border border-ink text-ink",
-                  ]'
-                  :title="y"
-                >
-                  {{ y.slice(-2) }}
-                </span>
+                ×{{ rec.talks.length }}
               </span>
             </span>
-            <!-- 展開/折りたたみアイコン（+/−） -->
+            <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化。名前は行ボタンの aria-label に集約） -->
             <span
               aria-hidden="true"
-              class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+              class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
             >
-              {{ openRows.has(rec.name) ? "−" : "+" }}
-            </span>
-          </button>
-          <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
-          <div
-            v-if="openRows.has(rec.name)"
-            class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
-          >
-            <!-- スピーカープロフィールページへのリンク -->
-            <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
-              :href="`/speakers/${encodeURIComponent(rec.name)}`"
-            >
-              {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-            </a>
-            <!-- @vize:ignore-end -->
-            <!-- 登壇一覧リスト -->
-            <ol class="list-none p-0 m-0 mt-[14px]">
-              <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
-              <li
-                v-for="(talk, k) in rec.talks"
-                :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-                class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
-                :class='k === 0 ? "border-t-0" : ""'
+              <span
+                v-for="y in YEARS"
+                :key="y"
+                class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
+                :class='[
+                  rec.years.includes(y) && selectedYear === y
+                    ? "bg-accent border border-accent text-accent-ink"
+                    : rec.years.includes(y)
+                      ? "bg-ink border border-ink text-paper"
+                      : "border border-ink text-ink",
+                ]'
+                :title="y"
               >
-                <!-- 開催年リンク（年度別ページへ） -->
-                <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+                {{ y.slice(-2) }}
+              </span>
+            </span>
+          </span>
+          <!-- 展開/折りたたみアイコン（+/−） -->
+          <span
+            aria-hidden="true"
+            class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+          >
+            {{ openRows.has(rec.name) ? "−" : "+" }}
+          </span>
+        </button>
+        <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
+        <div
+          v-if="openRows.has(rec.name)"
+          :id="speakerPanelId(rec.name)"
+          class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
+        >
+          <!-- スピーカープロフィールページへのリンク -->
+          <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
+            :href="`/speakers/${encodeURIComponent(rec.name)}`"
+          >
+            {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+          </a>
+          <!-- @vize:ignore-end -->
+          <!-- 登壇一覧リスト -->
+          <ol class="list-none p-0 m-0 mt-[14px]">
+            <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
+            <li
+              v-for="(talk, k) in rec.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
+              :class='k === 0 ? "border-t-0" : ""'
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+              <!-- @vize:ignore-start -->
+              <a
+                class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
+                :href="`/${talk.year}`"
+              >
+                {{ talk.year }}
+              </a>
+              <!-- @vize:ignore-end -->
+              <div class="flex flex-col gap-y-[8px]">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
                 <!-- @vize:ignore-start -->
                 <a
-                  class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
-                  :href="`/${talk.year}`"
+                  class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
                 >
-                  {{ talk.year }}
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ talk.title || t.tbd }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
                 </a>
                 <!-- @vize:ignore-end -->
-                <div class="flex flex-col gap-y-[8px]">
-                  <!-- トークタイトル（外部リンク） -->
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="talk.url"
-                  >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='talk.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
+                    <template v-if="ci > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
+                      :href="`/speakers/${encodeURIComponent(cn)}`"
                     >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ talk.title || t.tbd }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
-                    </span>
-                  </a>
-                  <!-- @vize:ignore-end -->
-                  <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-                  <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                    w/
-                    <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
-                      <template v-if="ci > 0">
-                        ,
-                      </template>
-                      <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                      <!-- @vize:ignore-start -->
-                      <a
-                        class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
-                        :href="`/speakers/${encodeURIComponent(cn)}`"
-                      >
-                        {{ cn }}
-                      </a>
-                      <!-- @vize:ignore-end -->
-                    </span>
+                      {{ cn }}
+                    </a>
+                    <!-- @vize:ignore-end -->
                   </span>
-                </div>
-              </li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </section>
-  </main>
+                </span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/SkipLinks.test.ts
+++ b/src/components/SkipLinks.test.ts
@@ -5,8 +5,8 @@ import SkipLinks from "./SkipLinks.vue";
 describe("SkipLinks", () => {
   it("本文へのスキップリンクを先頭に置く", () => {
     const wrapper = mount(SkipLinks, {
-      props: {
-        extra: [{ href: "#directory-list", label: "スピーカー一覧へ" }],
+      slots: {
+        default: '<a class="skip-link" href="#directory-list">スピーカー一覧へ</a>',
       },
     });
 

--- a/src/components/SkipLinks.test.ts
+++ b/src/components/SkipLinks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import SkipLinks from "./SkipLinks.vue";
+
+describe("SkipLinks", () => {
+  it("本文へのスキップリンクを先頭に置く", () => {
+    const wrapper = mount(SkipLinks, {
+      props: {
+        extra: [{ href: "#directory-list", label: "スピーカー一覧へ" }],
+      },
+    });
+
+    const links = wrapper.findAll("a.skip-link");
+    expect(wrapper.get("nav").attributes("aria-label")).toBe("スキップリンク");
+    expect(links[0]?.attributes("href")).toBe("#main");
+    expect(links[0]?.text()).toBe("本文へ");
+    expect(links[1]?.attributes("href")).toBe("#directory-list");
+  });
+});

--- a/src/components/SkipLinks.vue
+++ b/src/components/SkipLinks.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
-const { extra } = defineProps<{
-  extra?: Array<{ href: string; label: string }>;
-}>();
-
 const { t } = useVfjsI18n();
 </script>
 
@@ -13,8 +9,6 @@ const { t } = useVfjsI18n();
     <a class="skip-link" href="#main">
       {{ t.skip_to_main }}
     </a>
-    <a v-for="link in extra ?? []" :key="link.href" class="skip-link" :href="link.href">
-      {{ link.label }}
-    </a>
+    <slot />
   </nav>
 </template>

--- a/src/components/SkipLinks.vue
+++ b/src/components/SkipLinks.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useVfjsI18n } from "../composables/useVfjsI18n";
+
+const { extra } = defineProps<{
+  extra?: Array<{ href: string; label: string }>;
+}>();
+
+const { t } = useVfjsI18n();
+</script>
+
+<template>
+  <nav class="skip-nav" :aria-label="t.skip_links">
+    <a class="skip-link" href="#main">
+      {{ t.skip_to_main }}
+    </a>
+    <a v-for="link in extra ?? []" :key="link.href" class="skip-link" :href="link.href">
+      {{ link.label }}
+    </a>
+  </nav>
+</template>

--- a/src/components/YearFilterBar.test.ts
+++ b/src/components/YearFilterBar.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaYearCounts } from "../../musea/sample-data";
+import YearFilterBar from "./YearFilterBar.vue";
+
+describe("YearFilterBar", () => {
+  it("選択中の年度ボタンに aria-pressed を付ける", async () => {
+    const wrapper = mount(YearFilterBar, {
+      props: {
+        selectedYear: "all",
+        counts: museaYearCounts,
+      },
+    });
+
+    const buttons = wrapper.findAll('[role="group"] button');
+    expect(buttons[0]?.attributes("aria-pressed")).toBe("true");
+    expect(buttons[0]?.text()).toContain("選択中");
+    expect(buttons.some((button) => button.attributes("aria-pressed") === "false")).toBe(true);
+
+    await buttons.find((button) => button.text().startsWith("2025"))?.trigger("click");
+    expect(wrapper.emitted("update:selectedYear")?.[0]).toEqual(["2025"]);
+  });
+});

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useId } from "vue";
 import { YEARS } from "../../types";
 import type { AcceptedYear } from "../../types";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
@@ -13,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useVfjsI18n();
+const yearFilterLabelId = useId();
 
 function selectAllYears() {
   emit("update:selectedYear", "all");
@@ -27,10 +29,10 @@ function selectYear(year: AcceptedYear) {
   <div class="px-pad-x py-3.5 border-b border-rule-soft" role="region" :aria-label="t.filter_year">
     <!-- 年度選択ボタングループ -->
     <div class="flex items-center flex-wrap gap-1.5">
-      <span id="year-filter-label" class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
+      <span :id="yearFilterLabelId" class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
         {{ t.filter_year }}
       </span>
-      <div aria-labelledby="year-filter-label" class="flex gap-1.5 flex-wrap" role="group">
+      <div class="flex gap-1.5 flex-wrap" role="group" :aria-labelledby="yearFilterLabelId">
         <!-- 全年度選択ボタン（スピーカー総数を表示） -->
         <button
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -27,14 +27,15 @@ function selectYear(year: AcceptedYear) {
   <div class="px-pad-x py-3.5 border-b border-rule-soft" role="region" :aria-label="t.filter_year">
     <!-- 年度選択ボタングループ -->
     <div class="flex items-center flex-wrap gap-1.5">
-      <span class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
+      <span id="year-filter-label" class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
         {{ t.filter_year }}
       </span>
-      <div class="flex gap-1.5 flex-wrap" role="group" :aria-label="t.filter_year">
+      <div aria-labelledby="year-filter-label" class="flex gap-1.5 flex-wrap" role="group">
         <!-- 全年度選択ボタン（スピーカー総数を表示） -->
         <button
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === "all" ? "true" : "false"'
           :class='selectedYear === "all"
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
@@ -42,6 +43,9 @@ function selectYear(year: AcceptedYear) {
           @click="selectAllYears"
         >
           ALL · {{ counts.all }}
+          <span v-if='selectedYear === "all"' class="sr-only">
+            {{ t.selected }}
+          </span>
         </button>
         <!-- 各開催年ごとの選択ボタン（その年のスピーカー数を表示） -->
         <button
@@ -49,6 +53,7 @@ function selectYear(year: AcceptedYear) {
           :key="y"
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === y ? "true" : "false"'
           :class='selectedYear === y
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
@@ -56,6 +61,9 @@ function selectYear(year: AcceptedYear) {
           @click="() => selectYear(y)"
         >
           {{ y }} · {{ counts[y] }}
+          <span v-if="selectedYear === y" class="sr-only">
+            {{ t.selected }}
+          </span>
         </button>
       </div>
     </div>

--- a/src/composables/useVfjsI18n.ts
+++ b/src/composables/useVfjsI18n.ts
@@ -32,6 +32,21 @@ export interface VfjsTranslations {
   not_found_description: string;
   year_total_talks: (n: number) => string;
   appearance_count: (n: number) => string;
+  skip_links: string;
+  skip_to_main: string;
+  skip_to_footer: string;
+  skip_to_years: string;
+  skip_to_directory: string;
+  view_mode: string;
+  selected: string;
+  sort_label: string;
+  sort_appearances: string;
+  sort_name_asc: string;
+  sort_name_desc: string;
+  sort_latest: string;
+  directory_heading: (count: number, sortLabel: string) => string;
+  result_count: (shown: number, total: number) => string;
+  directory_row_label: (name: string, count: number, expanded: boolean) => string;
 }
 
 const translations: Record<"ja" | "en", VfjsTranslations> = {
@@ -68,6 +83,23 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     not_found_description: "指定されたページは存在しないか、移動した可能性があります。",
     year_total_talks: (n: number) => `全 ${n} 発表`,
     appearance_count: (n: number) => `${n}回登壇`,
+    skip_links: "スキップリンク",
+    skip_to_main: "本文へ",
+    skip_to_footer: "フッターへ",
+    skip_to_years: "年度一覧へ",
+    skip_to_directory: "スピーカー一覧へ",
+    view_mode: "表示切替",
+    selected: "選択中",
+    sort_label: "並び替え",
+    sort_appearances: "登壇回数の多い順",
+    sort_name_asc: "名前順（A→Z）",
+    sort_name_desc: "名前順（Z→A）",
+    sort_latest: "最新登壇年の新しい順",
+    directory_heading: (count: number, sortLabel: string) =>
+      `スピーカー一覧（${count}名・${sortLabel}）`,
+    result_count: (shown: number, total: number) => `${total}件中${shown}件を表示`,
+    directory_row_label: (name: string, count: number, expanded: boolean) =>
+      `${name}、${count}回登壇、${expanded ? "詳細を閉じる" : "詳細を開く"}`,
   },
   en: {
     nav_all_label: "All speakers",
@@ -102,6 +134,22 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     not_found_description: "The page you requested does not exist or may have moved.",
     year_total_talks: (n: number) => `${n} talks total`,
     appearance_count: (n: number) => `${n} appearance${n > 1 ? "s" : ""}`,
+    skip_links: "Skip links",
+    skip_to_main: "Skip to content",
+    skip_to_footer: "Skip to footer",
+    skip_to_years: "Skip to years",
+    skip_to_directory: "Skip to speaker list",
+    view_mode: "View mode",
+    selected: "Selected",
+    sort_label: "Sort",
+    sort_appearances: "Most appearances",
+    sort_name_asc: "Name A to Z",
+    sort_name_desc: "Name Z to A",
+    sort_latest: "Latest year",
+    directory_heading: (count: number, sortLabel: string) => `Speakers (${count}, ${sortLabel})`,
+    result_count: (shown: number, total: number) => `Showing ${shown} of ${total}`,
+    directory_row_label: (name: string, count: number, expanded: boolean) =>
+      `${name}, ${count} appearance${count > 1 ? "s" : ""}, ${expanded ? "Collapse details" : "Expand details"}`,
   },
 };
 

--- a/src/islands/HomePageIsland.test.ts
+++ b/src/islands/HomePageIsland.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakers } from "../../musea/sample-data";
+import HomePageIsland from "./HomePageIsland.vue";
+
+describe("HomePageIsland", () => {
+  it("スキップリンクと APG タブで表示を切り替える", async () => {
+    const wrapper = mount(HomePageIsland, {
+      attachTo: document.body,
+      props: { allSpeakers: museaSpeakers },
+    });
+
+    expect(wrapper.get(".skip-link").attributes("href")).toBe("#main");
+    expect(wrapper.get("#main").exists()).toBe(true);
+
+    const tablist = wrapper.get('[role="tablist"]');
+    expect(tablist.attributes("aria-label")).toBe("表示切替");
+
+    const chronicleTab = wrapper.get("#tab-chronicle");
+    const directoryTab = wrapper.get("#tab-directory");
+    expect(chronicleTab.attributes("role")).toBe("tab");
+    expect(chronicleTab.attributes("aria-controls")).toBe("panel-chronicle");
+    expect(chronicleTab.attributes("aria-selected")).toBe("true");
+    expect(chronicleTab.attributes("tabindex")).toBe("0");
+    expect(directoryTab.attributes("tabindex")).toBe("-1");
+    expect(wrapper.get("#panel-chronicle").attributes("role")).toBe("tabpanel");
+
+    await chronicleTab.trigger("keydown", { key: "ArrowRight" });
+    expect(directoryTab.attributes("aria-selected")).toBe("true");
+    expect(directoryTab.attributes("tabindex")).toBe("0");
+    expect(chronicleTab.attributes("tabindex")).toBe("-1");
+    expect(wrapper.get("#panel-directory").attributes("role")).toBe("tabpanel");
+    expect(wrapper.get("#panel-directory").attributes("aria-labelledby")).toBe("tab-directory");
+
+    wrapper.unmount();
+  });
+});

--- a/src/islands/HomePageIsland.test.ts
+++ b/src/islands/HomePageIsland.test.ts
@@ -16,21 +16,26 @@ describe("HomePageIsland", () => {
     const tablist = wrapper.get('[role="tablist"]');
     expect(tablist.attributes("aria-label")).toBe("表示切替");
 
-    const chronicleTab = wrapper.get("#tab-chronicle");
-    const directoryTab = wrapper.get("#tab-directory");
-    expect(chronicleTab.attributes("role")).toBe("tab");
-    expect(chronicleTab.attributes("aria-controls")).toBe("panel-chronicle");
+    const tabs = wrapper.findAll('[role="tab"]');
+    const chronicleTab = tabs[0]!;
+    const directoryTab = tabs[1]!;
     expect(chronicleTab.attributes("aria-selected")).toBe("true");
     expect(chronicleTab.attributes("tabindex")).toBe("0");
     expect(directoryTab.attributes("tabindex")).toBe("-1");
-    expect(wrapper.get("#panel-chronicle").attributes("role")).toBe("tabpanel");
+    expect(chronicleTab.attributes("aria-controls")).toBeTruthy();
+
+    const chroniclePanel = wrapper.get('[role="tabpanel"]');
+    expect(chroniclePanel.attributes("id")).toBe(chronicleTab.attributes("aria-controls"));
+    expect(chroniclePanel.attributes("aria-labelledby")).toBe(chronicleTab.attributes("id"));
 
     await chronicleTab.trigger("keydown", { key: "ArrowRight" });
     expect(directoryTab.attributes("aria-selected")).toBe("true");
     expect(directoryTab.attributes("tabindex")).toBe("0");
     expect(chronicleTab.attributes("tabindex")).toBe("-1");
-    expect(wrapper.get("#panel-directory").attributes("role")).toBe("tabpanel");
-    expect(wrapper.get("#panel-directory").attributes("aria-labelledby")).toBe("tab-directory");
+
+    const directoryPanel = wrapper.get('[role="tabpanel"]');
+    expect(directoryPanel.attributes("id")).toBe(directoryTab.attributes("aria-controls"));
+    expect(directoryPanel.attributes("aria-labelledby")).toBe(directoryTab.attributes("id"));
 
     wrapper.unmount();
   });

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, useId, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -46,17 +46,10 @@ const stats = computed(() => {
   };
 });
 
-const skipExtra = computed(() =>
-  view.value === "chronicle"
-    ? [
-        { href: "#year-list", label: t.value.skip_to_years },
-        { href: "#site-footer", label: t.value.skip_to_footer },
-      ]
-    : [
-        { href: "#directory-list", label: t.value.skip_to_directory },
-        { href: "#site-footer", label: t.value.skip_to_footer },
-      ],
-);
+const tabChronicleId = useId();
+const tabDirectoryId = useId();
+const panelChronicleId = useId();
+const panelDirectoryId = useId();
 
 function showChronicle() {
   view.value = "chronicle";
@@ -109,7 +102,17 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 
 <template>
   <div>
-    <SkipLinks :extra="skipExtra" />
+    <SkipLinks>
+      <a v-if='view === "chronicle"' class="skip-link" href="#year-list">
+        {{ t.skip_to_years }}
+      </a>
+      <a v-else class="skip-link" href="#directory-list">
+        {{ t.skip_to_directory }}
+      </a>
+      <a class="skip-link" href="#site-footer">
+        {{ t.skip_to_footer }}
+      </a>
+    </SkipLinks>
     <AppHeader />
     <!-- タイトル・統計情報 -->
     <AppMasthead :stats />
@@ -118,22 +121,22 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       class="flex gap-0 px-pad-x border-b border-rule bg-paper"
       role="tablist"
       :aria-label="t.view_mode"
-      @keydown="onTabKeydown"
     >
       <!-- 年度別クロニクルビュータブ -->
       <button
-        id="tab-chronicle"
         ref="tabChronicle"
-        aria-controls="panel-chronicle"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :id="tabChronicleId"
+        :aria-controls="panelChronicleId"
         :aria-selected='view === "chronicle"'
         :tabindex='view === "chronicle" ? 0 : -1'
         :class='view === "chronicle"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showChronicle"
+        @keydown="onTabKeydown"
       >
         {{ t.view_timeline }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -142,18 +145,19 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       </button>
       <!-- スピーカー名索引ディレクトリビュータブ -->
       <button
-        id="tab-directory"
         ref="tabDirectory"
-        aria-controls="panel-directory"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :id="tabDirectoryId"
+        :aria-controls="panelDirectoryId"
         :aria-selected='view === "index"'
         :tabindex='view === "index" ? 0 : -1'
         :class='view === "index"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showDirectory"
+        @keydown="onTabKeydown"
       >
         {{ t.view_index }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -165,9 +169,9 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       <!-- 年度別クロニクルビュー -->
       <ChronicleView
         v-if='view === "chronicle"'
-        id="panel-chronicle"
-        aria-labelledby="tab-chronicle"
         role="tabpanel"
+        :id="panelChronicleId"
+        :aria-labelledby="tabChronicleId"
         :all-speakers
         :query
         :selected-speaker
@@ -179,9 +183,9 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       <!-- スピーカー索引ディレクトリビュー -->
       <DirectoryView
         v-else
-        id="panel-directory"
-        aria-labelledby="tab-directory"
         role="tabpanel"
+        :id="panelDirectoryId"
+        :aria-labelledby="tabDirectoryId"
         :all-speakers
         :query
         :selected-speaker

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -7,6 +7,7 @@ import AppHeader from "../components/AppHeader.vue";
 import AppMasthead from "../components/AppMasthead.vue";
 import ChronicleView from "../components/ChronicleView.vue";
 import DirectoryView from "../components/DirectoryView.vue";
+import SkipLinks from "../components/SkipLinks.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
 const { allSpeakers } = defineProps<{
@@ -16,6 +17,8 @@ const { allSpeakers } = defineProps<{
 const { t } = useVfjsI18n();
 
 const view = ref<"chronicle" | "index">("chronicle");
+const tabChronicle = ref<HTMLButtonElement | null>(null);
+const tabDirectory = ref<HTMLButtonElement | null>(null);
 
 onMounted(() => {
   const storedView = localStorage.getItem("vfjs:view") as "chronicle" | "index" | null;
@@ -43,12 +46,52 @@ const stats = computed(() => {
   };
 });
 
+const skipExtra = computed(() =>
+  view.value === "chronicle"
+    ? [
+        { href: "#year-list", label: t.value.skip_to_years },
+        { href: "#site-footer", label: t.value.skip_to_footer },
+      ]
+    : [
+        { href: "#directory-list", label: t.value.skip_to_directory },
+        { href: "#site-footer", label: t.value.skip_to_footer },
+      ],
+);
+
 function showChronicle() {
   view.value = "chronicle";
 }
 
 function showDirectory() {
   view.value = "index";
+}
+
+function focusTab(next: "chronicle" | "index") {
+  const el = next === "chronicle" ? tabChronicle.value : tabDirectory.value;
+  el?.focus();
+}
+
+function onTabKeydown(event: KeyboardEvent) {
+  const order = ["chronicle", "index"] as const;
+  const current = order.indexOf(view.value);
+  let next = current;
+  if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+    next = (current + 1) % order.length;
+  } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+    next = (current - 1 + order.length) % order.length;
+  } else if (event.key === "Home") {
+    next = 0;
+  } else if (event.key === "End") {
+    next = order.length - 1;
+  } else {
+    return;
+  }
+  event.preventDefault();
+  const nextView = order[next]!;
+  view.value = nextView;
+  nextTick(() => {
+    focusTab(nextView);
+  });
 }
 
 function updateQuery(value: string) {
@@ -66,21 +109,27 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 
 <template>
   <div>
+    <SkipLinks :extra="skipExtra" />
     <AppHeader />
     <!-- タイトル・統計情報 -->
     <AppMasthead :stats />
     <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
     <div
-      aria-label="View mode"
       class="flex gap-0 px-pad-x border-b border-rule bg-paper"
       role="tablist"
+      :aria-label="t.view_mode"
+      @keydown="onTabKeydown"
     >
       <!-- 年度別クロニクルビュータブ -->
       <button
+        id="tab-chronicle"
+        ref="tabChronicle"
+        aria-controls="panel-chronicle"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
         :aria-selected='view === "chronicle"'
+        :tabindex='view === "chronicle" ? 0 : -1'
         :class='view === "chronicle"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
@@ -93,10 +142,14 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       </button>
       <!-- スピーカー名索引ディレクトリビュータブ -->
       <button
+        id="tab-directory"
+        ref="tabDirectory"
+        aria-controls="panel-directory"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
         :aria-selected='view === "index"'
+        :tabindex='view === "index" ? 0 : -1'
         :class='view === "index"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
@@ -108,29 +161,36 @@ function updateSelectedYear(value: AcceptedYear | "all") {
         </span>
       </button>
     </div>
-    <!-- 選択中のビューに応じてコンポーネントを切り替え -->
-    <!-- 年度別クロニクルビュー -->
-    <ChronicleView
-      v-if='view === "chronicle"'
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
-    <!-- スピーカー索引ディレクトリビュー -->
-    <DirectoryView
-      v-else
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
+    <main id="main">
+      <!-- 年度別クロニクルビュー -->
+      <ChronicleView
+        v-if='view === "chronicle"'
+        id="panel-chronicle"
+        aria-labelledby="tab-chronicle"
+        role="tabpanel"
+        :all-speakers
+        :query
+        :selected-speaker
+        :selected-year
+        @update:query="updateQuery"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:selected-year="updateSelectedYear"
+      />
+      <!-- スピーカー索引ディレクトリビュー -->
+      <DirectoryView
+        v-else
+        id="panel-directory"
+        aria-labelledby="tab-directory"
+        role="tabpanel"
+        :all-speakers
+        :query
+        :selected-speaker
+        :selected-year
+        @update:query="updateQuery"
+        @update:selected-speaker="updateSelectedSpeaker"
+        @update:selected-year="updateSelectedYear"
+      />
+    </main>
     <AppFooter />
   </div>
 </template>

--- a/src/islands/SpeakerPageIsland.test.ts
+++ b/src/islands/SpeakerPageIsland.test.ts
@@ -30,5 +30,7 @@ describe("SpeakerPageIsland", () => {
     expect(wrapper.html()).toContain("Vue.js Advanced");
     expect(wrapper.html()).toContain("2023");
     expect(wrapper.html()).toContain("2024");
+    expect(wrapper.get("#main").exists()).toBe(true);
+    expect(wrapper.get(".skip-link").attributes("href")).toBe("#main");
   });
 });

--- a/src/islands/SpeakerPageIsland.vue
+++ b/src/islands/SpeakerPageIsland.vue
@@ -46,131 +46,133 @@ const record = computed(() => {
     <SkipLinks />
     <AppHeader />
     <!-- スピーカーページのメインコンテンツ（該当スピーカーが存在する場合） -->
-    <main v-if="found" id="main">
-      <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
-      <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
-        <!-- スピーカー名 -->
-        <h1
-          class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
-          :lang='hasJapanese(record.name) ? "ja" : "en"'
-        >
-          <ruby v-if='record.nameRuby && lang === "ja"'>
-            {{ record.name }}
-            <rt>
-              {{ record.nameRuby }}
-            </rt>
-          </ruby>
-          <template v-else>
-            {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
-          </template>
-        </h1>
-        <div class="font-mono text-ink-2">
-          <!-- 総登壇回数 -->
-          <div>
-            {{ t.appearance_count(record.talks.length) }}
-          </div>
-          <!-- 登壇年度のリスト（各年度ページへのリンク） -->
-          <div class="mt-2 text-[12px] text-ink-2">
-            {{ t.years_appeared }}:
-            <span v-for="(year, index) in record.years" :key="year">
-              <template v-if="index > 0">
-                ,
-              </template>
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${year}`">
-                {{ year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-          </div>
-        </div>
-      </header>
-      <!-- 関連トーク一覧セクション -->
-      <section class="px-pad-x py-10">
-        <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
-          {{ t.related_talks }}
-        </h2>
-        <ul class="list-none p-0 m-0">
-          <li
-            v-for="talk in record.talks"
-            :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-            class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+    <main id="main">
+      <template v-if="found">
+        <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
+        <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
+          <!-- スピーカー名 -->
+          <h1
+            class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
+            :lang='hasJapanese(record.name) ? "ja" : "en"'
           >
-            <!-- 開催年リンク（年度別ページへ） -->
-            <span class="font-mono text-[12px] text-center pt-[3px]">
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
-                {{ talk.year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-            <div class="flex flex-col gap-y-2">
-              <!-- トークタイトル（外部リンク） -->
-              <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-              <!-- @vize:ignore-start -->
-              <a
-                class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
-                rel="noopener noreferrer"
-                target="_blank"
-                :href="talk.url"
-              >
-                <!-- パネルセッションのフォーマットバッジ -->
-                <span
-                  v-if='talk.format === "panel"'
-                  class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
-                >
-                  {{ t.session_format_panel }}
-                </span>
-                <span>
-                  <span
-                    class="group-hover:underline"
-                    :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
-                  >
-                    {{ talk.title || t.tbd }}
-                  </span>
-                  <span class="text-[10px] ml-1">
-                    ({{ t.external }})
-                  </span>
-                </span>
-              </a>
-              <!-- @vize:ignore-end -->
-              <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-              <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                w/
-                <span
-                  v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
-                  :key="coSpeakerName"
-                  class="contents"
-                >
-                  <template v-if="coSpeakerIndex > 0">
-                    ,
-                  </template>
-                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-ink underline hover:no-underline"
-                    :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
-                  >
-                    {{ coSpeakerName }}
-                  </a>
-                  <!-- @vize:ignore-end -->
-                </span>
+            <ruby v-if='record.nameRuby && lang === "ja"'>
+              {{ record.name }}
+              <rt>
+                {{ record.nameRuby }}
+              </rt>
+            </ruby>
+            <template v-else>
+              {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
+            </template>
+          </h1>
+          <div class="font-mono text-ink-2">
+            <!-- 総登壇回数 -->
+            <div>
+              {{ t.appearance_count(record.talks.length) }}
+            </div>
+            <!-- 登壇年度のリスト（各年度ページへのリンク） -->
+            <div class="mt-2 text-[12px] text-ink-2">
+              {{ t.years_appeared }}:
+              <span v-for="(year, index) in record.years" :key="year">
+                <template v-if="index > 0">
+                  ,
+                </template>
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${year}`">
+                  {{ year }}
+                </a>
+                <!-- @vize:ignore-end -->
               </span>
             </div>
-          </li>
-        </ul>
-      </section>
-    </main>
-    <!-- スピーカーが存在しない場合 -->
-    <main v-else id="main" class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
-      <h1 class="font-display text-[40px] text-ink m-0">
-        Speaker Not Found
-      </h1>
-      <p>
-        {{ speakerName }}
-      </p>
+          </div>
+        </header>
+        <!-- 関連トーク一覧セクション -->
+        <section class="px-pad-x py-10">
+          <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
+            {{ t.related_talks }}
+          </h2>
+          <ul class="list-none p-0 m-0">
+            <li
+              v-for="talk in record.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <span class="font-mono text-[12px] text-center pt-[3px]">
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
+                  {{ talk.year }}
+                </a>
+                <!-- @vize:ignore-end -->
+              </span>
+              <div class="flex flex-col gap-y-2">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span>
+                    <span
+                      class="group-hover:underline"
+                      :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
+                    >
+                      {{ talk.title || t.tbd }}
+                    </span>
+                    <span class="text-[10px] ml-1">
+                      ({{ t.external }})
+                    </span>
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span
+                    v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
+                    :key="coSpeakerName"
+                    class="contents"
+                  >
+                    <template v-if="coSpeakerIndex > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink underline hover:no-underline"
+                      :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
+                    >
+                      {{ coSpeakerName }}
+                    </a>
+                    <!-- @vize:ignore-end -->
+                  </span>
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </template>
+      <!-- スピーカーが存在しない場合 -->
+      <div v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
+        <h1 class="font-display text-[40px] text-ink m-0">
+          Speaker Not Found
+        </h1>
+        <p>
+          {{ speakerName }}
+        </p>
+      </div>
     </main>
     <AppFooter />
   </div>

--- a/src/islands/SpeakerPageIsland.vue
+++ b/src/islands/SpeakerPageIsland.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import type { SpeakerWithYear } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
+import SkipLinks from "../components/SkipLinks.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { hasJapanese } from "../utils/speakerMap";
@@ -42,9 +43,10 @@ const record = computed(() => {
 
 <template>
   <div>
+    <SkipLinks />
     <AppHeader />
     <!-- スピーカーページのメインコンテンツ（該当スピーカーが存在する場合） -->
-    <template v-if="found">
+    <main v-if="found" id="main">
       <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
       <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
         <!-- スピーカー名 -->
@@ -160,9 +162,9 @@ const record = computed(() => {
           </li>
         </ul>
       </section>
-    </template>
+    </main>
     <!-- スピーカーが存在しない場合 -->
-    <main v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
+    <main v-else id="main" class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
       <h1 class="font-display text-[40px] text-ink m-0">
         Speaker Not Found
       </h1>

--- a/src/islands/YearPageIsland.test.ts
+++ b/src/islands/YearPageIsland.test.ts
@@ -22,5 +22,7 @@ describe("YearPageIsland", () => {
     expect(wrapper.html()).toContain("2024");
     expect(wrapper.html()).toContain("John Doe");
     expect(wrapper.html()).toContain("Vue.js Advanced");
+    expect(wrapper.get("#main").exists()).toBe(true);
+    expect(wrapper.get(".skip-link").attributes("href")).toBe("#main");
   });
 });

--- a/src/islands/YearPageIsland.vue
+++ b/src/islands/YearPageIsland.vue
@@ -2,6 +2,7 @@
 import type { SpeakerInfo } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
+import SkipLinks from "../components/SkipLinks.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
 const { found, speakers, year } = defineProps<{
@@ -15,9 +16,10 @@ const { t, lang } = useVfjsI18n();
 
 <template>
   <div>
+    <SkipLinks />
     <AppHeader />
     <!-- 年度ページのメインコンテンツ -->
-    <main>
+    <main id="main">
       <template v-if="found">
         <!-- 年度ページのヘッダー（タイトル・トーク数・公式サイトリンク） -->
         <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">

--- a/src/routes/NotFoundRoute.vue
+++ b/src/routes/NotFoundRoute.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import AppFooter from "../components/AppFooter.vue";
 import AppHeader from "../components/AppHeader.vue";
+import SkipLinks from "../components/SkipLinks.vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
 const { t } = useVfjsI18n();
@@ -8,8 +9,9 @@ const { t } = useVfjsI18n();
 
 <template>
   <div>
+    <SkipLinks />
     <AppHeader />
-    <main class="min-h-[60vh] px-pad-x py-[clamp(64px,10vw,140px)] border-b border-rule">
+    <main id="main" class="min-h-[60vh] px-pad-x py-[clamp(64px,10vw,140px)] border-b border-rule">
       <p class="font-mono text-[12px] tracking-[0.12em] uppercase text-ink-3 mb-4.5">
         404
       </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

#836 の Major サブイシュー 10 件をまとめて直します。Critical はなく、見出し・選択状態・スキップリンク・コントラスト・ライブリージョンなど、キーボード／スクリーンリーダーで情報を取れない箇所を優先しています。

Closes #837
Closes #838
Closes #839
Closes #840
Closes #841
Closes #842
Closes #843
Closes #844
Closes #845
Closes #846

親: #836

## 変更内容

- Chronicle の年を `h2` にする（#837）
- Directory に `h2` を置き、`ol[aria-labelledby]` で紐付ける（#838）
- 表示切替を APG Tabs にする（`id` / `aria-controls` / `tabpanel` / 矢印・Home/End / 非選択 `tabindex="-1"`）（#839）
- 年度フィルタに `aria-pressed` と「選択中」（#840）
- Directory のソートを日本語ラベル + `aria-pressed` にする（#841）
- 「本文へ」「年度一覧へ / スピーカー一覧へ」「フッターへ」のスキップリンク（#842）
- ダーク `--ink-3` を `#8a8a82` に変更（`#1c1c19` 上で約 4.91:1）（#843）
- `html { scroll-padding-top: 72px }` で sticky header 下にフォーカスが隠れないようにする（#844）
- Directory 行ボタンを短い `aria-label` にし、年度グリッドを `aria-hidden`、バッジを実テキスト化（#845）
- 件数を `role="status"` の完全文で通知する（#846）

## 確認

- [x] `vp run lint`
- [x] `vp run format:check`
- [x] `vp run typecheck`
- [x] `vp test run`（12 files / 31 tests）
- [x] トップ / 年 / スピーカーでスキップリンクと `main#main` を確認
- [x] Directory の見出し・ソート・行展開・検索件数 / 空状態を確認
- [x] ダークモードで非選択タブのコントラストを確認

[Skip links](https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskip_links_focused.webp)
[Chronicle year headings](https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_chronicle_2018.webp)
[Directory heading and sort](https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_directory_heading.webp)
[Empty search status](https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_empty_search.webp)
[a11y_major_ui_demo.mp4](https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa11y_major_ui_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87449700-2577-462b-93c4-b641b2e18761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87449700-2577-462b-93c4-b641b2e18761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

