### PR TITLE
fix(a11y): address Major accessibility issues from #836

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -26,7 +26,7 @@
     --rule-softer: rgba(232, 228, 220, 0.07);
     --ink: #e8e4dc;
     --ink-2: #b4b0a8;
-    --ink-3: #7a7a72;
+    --ink-3: #878785;
     --accent: #2ed9a8;
     --accent-ink: #0d2820;
   }
@@ -40,7 +40,7 @@
   --rule-softer: rgba(232, 228, 220, 0.07);
   --ink: #e8e4dc;
   --ink-2: #b4b0a8;
-  --ink-3: #7a7a72;
+  --ink-3: #878785;
   --accent: #2ed9a8;
   --accent-ink: #0d2820;
 }
@@ -91,6 +91,43 @@ body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-feature-settings: "ss01", "cv02", "cv11";
+}
+
+html {
+  scroll-padding-top: 72px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 8px 16px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-body);
+  font-size: 14px;
+  text-decoration: none;
+  transform: translateY(-100%);
+  transition: transform 0.15s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -20,6 +20,10 @@ function setEnglish() {
 </script>
 
 <template>
+  <!-- 本文へのスキップリンク -->
+  <a class="skip-link" href="#main">
+    {{ t.skip_to_content }}
+  </a>
   <!-- サイト全体のヘッダー（スクロール時にページ上部へ固定） -->
   <header class="border-b border-rule bg-paper sticky top-0 z-20 [backdrop-filter:saturate(1.1)]">
     <div class="flex flex-wrap justify-between items-center gap-2 py-[14px] px-pad-x">

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -60,6 +60,12 @@ const grouped = computed(() => {
   return Array.from(map.entries()).filter(([, arr]) => arr.length > 0);
 });
 
+const filterStatus = computed(() => {
+  const total = allSpeakers.length;
+  const shown = filtered.value.length;
+  return t.value.filter_result_status(shown, total);
+});
+
 function updateQuery(value: string) {
   emit("update:query", value);
 }
@@ -74,137 +80,136 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 </script>
 
 <template>
-  <main>
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- フィルター結果が0件のとき -->
-      <div
-        v-if="grouped.length === 0"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- フィルター結果の件数通知（スクリーンリーダー向け） -->
+    <div aria-atomic="true" aria-live="polite" class="sr-only" role="status">
+      {{ filterStatus }}
+    </div>
+    <!-- フィルター結果が0件のとき -->
+    <div
+      v-if="grouped.length === 0"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- 年度グループリスト -->
+    <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
+      <!-- 各年度グループ -->
+      <li
+        v-for="[year, arr] in grouped"
+        :key="year"
+        class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
       >
-        {{ t.empty }}
-      </div>
-      <!-- 年度グループリスト -->
-      <ol class="list-none p-0 m-0" :aria-label="t.nav_all_label">
-        <!-- 各年度グループ -->
-        <li
-          v-for="[year, arr] in grouped"
-          :key="year"
-          class="grid grid-cols-[minmax(200px,260px)_1fr] gap-[clamp(24px,4vw,64px)] border-b border-rule items-start px-pad-x py-[clamp(32px,5vw,72px)] max-[800px]:grid-cols-1 max-[800px]:gap-8"
+        <!-- 年度ラベル（スクロール時に上部に固定） -->
+        <div
+          class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
+          :id="`year-${year}`"
         >
-          <!-- 年度ラベル（スクロール時に上部に固定） -->
-          <div
-            class="flex flex-col items-start sticky top-[72px] max-[800px]:static"
-            :id="`year-${year}`"
+          <!-- 年度見出し（スクロール時に上部に固定） -->
+          <h2 class="m-0 font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink">
+            {{ year }}
+          </h2>
+          <!-- その年のトーク総数 -->
+          <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
+            {{ t.year_total_talks(arr.length) }}
+          </span>
+          <!-- 年度別ページへの矢印リンク -->
+          <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
+            :aria-label="t.year_speakers_link(year)"
+            :href="`/${year}`"
           >
-            <!-- 年度テキスト（表示専用） -->
-            <span
-              aria-hidden="true"
-              class="font-display font-[500] text-[clamp(72px,8vw,120px)] leading-[0.85] tabular-nums text-ink"
-            >
-              {{ year }}
-            </span>
-            <!-- その年のトーク総数 -->
-            <span class="font-mono text-[14px] tracking-[0.08em] uppercase text-ink-2 mt-2.5">
-              {{ t.year_total_talks(arr.length) }}
-            </span>
-            <!-- 年度別ページへの矢印リンク -->
-            <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-              :aria-label="`${year} speakers`"
-              :href="`/${year}`"
-            >
-              →
-            </a>
-            <!-- @vize:ignore-end -->
-          </div>
-          <!-- その年のスピーカー行リスト -->
-          <ol class="list-none p-0 m-0 border-t border-rule-soft">
-            <!-- 各スピーカー行 -->
-            <li
-              v-for="(s, i) in arr"
-              :key="`${year}-${i}`"
-              class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
-            >
-              <!-- 行番号（表示専用） -->
-              <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
-                <span>
-                  {{ String(i + 1).padStart(2, "0") }}
-                </span>
-              </div>
-              <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
-                <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
-                <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
-                  <span v-for="(n, ni) in s.name" :key="n" class="contents">
-                    <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
-                      ×
-                    </span>
-                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                    <!-- @vize:ignore-start -->
-                    <a
-                      class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
-                      :href="`/speakers/${encodeURIComponent(n)}`"
-                    >
-                      <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
-                        {{ n }}
-                        <rt>
-                          {{ s.nameRuby[ni] }}
-                        </rt>
-                      </ruby>
-                      <span v-else>
-                        {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
-                      </span>
-                    </a>
-                    <!-- @vize:ignore-end -->
+            →
+          </a>
+          <!-- @vize:ignore-end -->
+        </div>
+        <!-- その年のスピーカー行リスト -->
+        <ol class="list-none p-0 m-0 border-t border-rule-soft">
+          <!-- 各スピーカー行 -->
+          <li
+            v-for="(s, i) in arr"
+            :key="`${year}-${i}`"
+            class="grid grid-cols-[56px_1fr] gap-4 py-[18px] border-b border-rule-soft items-start"
+          >
+            <!-- 行番号（表示専用） -->
+            <div aria-hidden="true" class="font-mono text-[14px] text-ink-2 pt-[3px]">
+              <span>
+                {{ String(i + 1).padStart(2, "0") }}
+              </span>
+            </div>
+            <div class="flex flex-wrap gap-[clamp(16px,2vw,32px)] items-baseline">
+              <!-- スピーカー名（複数名対応・振り仮名・英語名対応、プロフィールページへのリンク） -->
+              <div class="flex flex-wrap gap-x-2 gap-y-1 basis-50 grow-1 font-display font-[500] text-[clamp(17px,1.5vw,22px)] tracking-[-0.01em] leading-[1.25]">
+                <span v-for="(n, ni) in s.name" :key="n" class="contents">
+                  <span v-if="ni > 0" aria-hidden="true" class="text-ink-2 font-normal">
+                    ×
                   </span>
-                </div>
-                <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
-                <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
                   <!-- @vize:ignore-start -->
                   <a
-                    v-if="s.title"
-                    class="text-ink-2 no-underline group hover:text-ink"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="s.url"
+                    class="text-ink border-b border-rule-soft pb-[1px] no-underline transition-colors hover:border-accent hover:text-accent"
+                    :href="`/speakers/${encodeURIComponent(n)}`"
                   >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='s.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
-                    >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ s.title }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
+                    <ruby v-if='s.nameRuby?.[ni] && lang === "ja"' lang="ja">
+                      {{ n }}
+                      <rt>
+                        {{ s.nameRuby[ni] }}
+                      </rt>
+                    </ruby>
+                    <span v-else>
+                      {{ lang === "en" && s.nameEn?.[ni] ? s.nameEn[ni] : n }}
                     </span>
                   </a>
                   <!-- @vize:ignore-end -->
-                  <!-- タイトル未決定時のプレースホルダー -->
-                  <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
-                    {{ t.tbd }}
-                  </span>
-                </div>
+                </span>
               </div>
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </section>
-  </main>
+              <!-- トークタイトル（外部リンク、未決定の場合は TBD 表示） -->
+              <div class="basis-0 grow-999 min-inline-[60%] text-[clamp(14px,1.1vw,16px)] text-ink-2 leading-[1.5]">
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  v-if="s.title"
+                  class="text-ink-2 no-underline group hover:text-ink"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="s.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='s.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ s.title }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- タイトル未決定時のプレースホルダー -->
+                <span v-else class="font-mono text-[12px] text-ink-2 uppercase tracking-[0.06em]">
+                  {{ t.tbd }}
+                </span>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, useId } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
@@ -23,6 +23,8 @@ const emit = defineEmits<{
 }>();
 
 const { t, lang } = useVfjsI18n();
+
+const directoryHeadingId = useId();
 
 const speakerMap = computed(() => buildSpeakerMap(allSpeakers));
 const allRecords = computed(() => Array.from(speakerMap.value.values()));
@@ -77,6 +79,37 @@ const filtered = computed<SpeakerRecord[]>(() => {
   return list;
 });
 
+const sortLabel = computed(() => {
+  if (sort.value === "appearances") return t.value.sort_appearances;
+  if (sort.value === "name-asc") return t.value.sort_name_asc;
+  if (sort.value === "name-desc") return t.value.sort_name_desc;
+  return t.value.sort_latest;
+});
+
+const directoryHeading = computed(() =>
+  t.value.directory_heading(filtered.value.length, sortLabel.value),
+);
+
+const filterStatus = computed(() =>
+  t.value.filter_result_status(filtered.value.length, allRecords.value.length),
+);
+
+function displayName(rec: SpeakerRecord) {
+  return lang.value === "en" && rec.nameEn ? rec.nameEn : rec.name;
+}
+
+function panelId(name: string) {
+  return `directory-panel-${encodeURIComponent(name)}`;
+}
+
+function rowLabel(rec: SpeakerRecord) {
+  const name = displayName(rec);
+  const count = rec.talks.length;
+  return openRows.value.has(rec.name)
+    ? t.value.row_collapse(name, count)
+    : t.value.row_expand(name, count);
+}
+
 const openRows = ref(new Set<string>());
 
 function toggleRow(name: string) {
@@ -113,223 +146,241 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 
 <template>
   <!-- ディレクトリビュー：スピーカーを人物単位でまとめ、アコーディオンで登壇履歴を表示するビュー -->
-  <main>
-    <section>
-      <!-- スピーカー名・キーワードによるフィルターバー -->
-      <SpeakerFilterBar
-        :query
-        :selected-speaker
-        :speaker-options
-        @update:query="updateQuery"
-        @update:selected-speaker="updateSelectedSpeaker"
-      />
-      <!-- 開催年度によるフィルターバー -->
-      <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
-      <!-- Sort header -->
-      <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
-      <div class="flex items-center gap-2 px-pad-x pt-4.5 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto">
-        <!-- 登壇回数の多い順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "appearances"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByAppearances"
-        >
-          Appearances ↓
-        </button>
-        <!-- 名前の昇順/降順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "name-asc" || sort === "name-desc"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="toggleNameSort"
-        >
-          Name {{ sort === "name-desc" ? "Z→A" : "A→Z" }}
-        </button>
-        <!-- 最新登壇年の新しい順でソートするボタン -->
-        <button
-          class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
-          type="button"
-          :class='sort === "latest"
-            ? "bg-ink text-paper border-ink"
-            : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
-          @click="sortByLatest"
-        >
-          Latest year ↓
-        </button>
-        <!-- フィルター済み件数 / 全体件数の表示 -->
-        <span class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap">
-          {{ String(filtered.length).padStart(3, "0") }} /
-          {{ String(allRecords.length).padStart(3, "0") }}
-        </span>
-      </div>
-      <!-- フィルター結果が0件のときの空状態メッセージ -->
-      <div
-        v-if="filtered.length === 0"
-        class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+  <section>
+    <!-- スピーカー名・キーワードによるフィルターバー -->
+    <SpeakerFilterBar
+      :query
+      :selected-speaker
+      :speaker-options
+      @update:query="updateQuery"
+      @update:selected-speaker="updateSelectedSpeaker"
+    />
+    <!-- 開催年度によるフィルターバー -->
+    <YearFilterBar :counts :selected-year @update:selected-year="updateSelectedYear" />
+    <!-- フィルター結果の件数通知（スクリーンリーダー向け） -->
+    <div aria-atomic="true" aria-live="polite" class="sr-only" role="status">
+      {{ filterStatus }}
+    </div>
+    <!-- Sort header -->
+    <!-- ソートボタンヘッダー（登壇回数・名前順・最新年で並び替え） -->
+    <div
+      class="flex items-center gap-2 px-pad-x pt-4.5 pb-2.5 border-b border-rule-soft font-mono overflow-x-auto"
+      role="group"
+      :aria-label="t.sort_group"
+    >
+      <!-- 登壇回数の多い順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "appearances" ? "true" : "false"'
+        :class='sort === "appearances"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="sortByAppearances"
       >
-        {{ t.empty }}
-      </div>
-      <!-- スピーカー一覧リスト -->
-      <ol class="list-none p-0 m-0">
-        <li
-          v-for="(rec, i) in filtered"
-          :key="rec.name"
-          class="border-b border-rule-softer"
-          :data-open='openRows.has(rec.name) ? "true" : "false"'
+        {{ t.sort_appearances }}
+      </button>
+      <!-- 名前の昇順/降順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "name-asc" || sort === "name-desc" ? "true" : "false"'
+        :class='sort === "name-asc" || sort === "name-desc"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="toggleNameSort"
+      >
+        {{ sort === "name-desc" ? t.sort_name_desc : t.sort_name_asc }}
+      </button>
+      <!-- 最新登壇年の新しい順でソートするボタン -->
+      <button
+        class="text-[12px] tracking-[0.06em] uppercase px-[10px] py-[5px] border cursor-pointer whitespace-nowrap"
+        type="button"
+        :aria-pressed='sort === "latest" ? "true" : "false"'
+        :class='sort === "latest"
+          ? "bg-ink text-paper border-ink"
+          : "border-rule text-ink-2 hover:text-ink hover:border-ink"'
+        @click="sortByLatest"
+      >
+        {{ t.sort_latest }}
+      </button>
+      <!-- フィルター済み件数 / 全体件数の表示 -->
+      <span
+        aria-hidden="true"
+        class="ml-auto text-[12px] tracking-[0.06em] text-ink-2 whitespace-nowrap"
+      >
+        {{ String(filtered.length).padStart(3, "0") }} /
+        {{ String(allRecords.length).padStart(3, "0") }}
+      </span>
+    </div>
+    <!-- フィルター結果が0件のときの空状態メッセージ -->
+    <div
+      v-if="filtered.length === 0"
+      class="px-pad-x py-20 text-center font-mono text-[13px] tracking-[0.05em] uppercase text-ink-2"
+    >
+      {{ t.empty }}
+    </div>
+    <!-- スピーカー一覧リスト -->
+    <h2 :id="directoryHeadingId" class="sr-only">
+      {{ directoryHeading }}
+    </h2>
+    <ol :aria-labelledby="directoryHeadingId" class="list-none p-0 m-0">
+      <li
+        v-for="(rec, i) in filtered"
+        :key="rec.name"
+        class="border-b border-rule-softer"
+        :data-open='openRows.has(rec.name) ? "true" : "false"'
+      >
+        <!-- スピーカー行の展開/折りたたみボタン -->
+        <button
+          class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
+          type="button"
+          :aria-controls="panelId(rec.name)"
+          :aria-expanded="openRows.has(rec.name)"
+          :aria-label="rowLabel(rec)"
+          :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
+          @click="() => toggleRow(rec.name)"
         >
-          <!-- スピーカー行の展開/折りたたみボタン -->
-          <button
-            class="w-full flex flex-wrap items-center gap-x-[12px] px-pad-x py-3.5 cursor-pointer text-left"
-            type="button"
-            :aria-expanded="openRows.has(rec.name)"
-            :class='openRows.has(rec.name) ? "bg-paper-2" : ""'
-            @click="() => toggleRow(rec.name)"
+          <span
+            aria-hidden="true"
+            class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center"
           >
-            <span class="basis-0 grow-999 min-inline-[50%] flex flex-wrap gap-2 justify-start items-center">
-              <!-- 行番号（表示専用） -->
-              <span aria-hidden="true" class="font-mono text-[12px] text-ink-2 tabular-nums">
-                {{ String(i + 1).padStart(3, "0") }}
-              </span>
-              <!-- スピーカー名（振り仮名・英語名対応） -->
-              <span
-                class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
-                :lang='hasJapanese(rec.name) ? "ja" : "en"'
-              >
-                <ruby v-if='rec.nameRuby && lang === "ja"'>
-                  {{ rec.name }}
-                  <rt>
-                    {{ rec.nameRuby }}
-                  </rt>
-                </ruby>
-                <template v-else>
-                  {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-                </template>
-                <!-- 複数回登壇バッジ（登壇回数を ×N 形式で表示。formatter の改行空白を避けるため data-count で描画） -->
-                <span
-                  v-if="rec.talks.length > 1"
-                  class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px] after:content-[attr(data-count)]"
-                  :aria-label="t.appearance_count(rec.talks.length)"
-                  :data-count="`×${rec.talks.length}`"
-                ></span>
-              </span>
-              <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
-              <span
-                class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]"
-                :aria-label='t.years_appeared + ": " + rec.years.join(", ")'
-              >
-                <span
-                  v-for="y in YEARS"
-                  :key="y"
-                  class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
-                  :class='[
-                    rec.years.includes(y) && selectedYear === y
-                      ? "bg-accent border border-accent text-accent-ink"
-                      : rec.years.includes(y)
-                        ? "bg-ink border border-ink text-paper"
-                        : "border border-ink text-ink",
-                  ]'
-                  :title="y"
-                >
-                  {{ y.slice(-2) }}
-                </span>
-              </span>
+            <!-- 行番号（表示専用） -->
+            <span class="font-mono text-[12px] text-ink-2 tabular-nums">
+              {{ String(i + 1).padStart(3, "0") }}
             </span>
-            <!-- 展開/折りたたみアイコン（+/−） -->
+            <!-- スピーカー名（振り仮名・英語名対応） -->
             <span
-              aria-hidden="true"
-              class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+              class="font-display text-[clamp(15px,1.2vw,18px)] font-[500] tracking-[-0.005em] text-ink"
+              :lang='hasJapanese(rec.name) ? "ja" : "en"'
             >
-              {{ openRows.has(rec.name) ? "−" : "+" }}
-            </span>
-          </button>
-          <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
-          <div
-            v-if="openRows.has(rec.name)"
-            class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
-          >
-            <!-- スピーカープロフィールページへのリンク -->
-            <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-            <!-- @vize:ignore-start -->
-            <a
-              class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
-              :href="`/speakers/${encodeURIComponent(rec.name)}`"
-            >
-              {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
-            </a>
-            <!-- @vize:ignore-end -->
-            <!-- 登壇一覧リスト -->
-            <ol class="list-none p-0 m-0 mt-[14px]">
-              <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
-              <li
-                v-for="(talk, k) in rec.talks"
-                :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-                class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
-                :class='k === 0 ? "border-t-0" : ""'
+              <ruby v-if='rec.nameRuby && lang === "ja"'>
+                {{ rec.name }}
+                <rt>
+                  {{ rec.nameRuby }}
+                </rt>
+              </ruby>
+              <template v-else>
+                {{ displayName(rec) }}
+              </template>
+              <!-- 複数回登壇バッジ -->
+              <span
+                v-if="rec.talks.length > 1"
+                class="font-mono bg-accent text-[12px] text-accent-ink ml-2 font-normal tracking-[0.02em] align-[2px] border border-accent px-1.25 py-[1px]"
               >
-                <!-- 開催年リンク（年度別ページへ） -->
-                <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+                ×{{ rec.talks.length }}
+              </span>
+            </span>
+            <!-- 登壇年度グリッド（各年のマスを塗りつぶして登壇済みかを可視化） -->
+            <span class="inline-grid gap-[3px] grow-999 justify-end [grid-template-columns:repeat(6,28px)]">
+              <span
+                v-for="y in YEARS"
+                :key="y"
+                class="w-7 h-[22px] flex items-center justify-center font-mono text-[12px] tracking-[0]"
+                :class='[
+                  rec.years.includes(y) && selectedYear === y
+                    ? "bg-accent border border-accent text-accent-ink"
+                    : rec.years.includes(y)
+                      ? "bg-ink border border-ink text-paper"
+                      : "border border-ink text-ink",
+                ]'
+                :title="y"
+              >
+                {{ y.slice(-2) }}
+              </span>
+            </span>
+          </span>
+          <!-- 展開/折りたたみアイコン（+/−） -->
+          <span
+            aria-hidden="true"
+            class="basis-6 grow-1 font-mono text-[16px] text-ink-3 text-center"
+          >
+            {{ openRows.has(rec.name) ? "−" : "+" }}
+          </span>
+        </button>
+        <!-- 展開時の詳細エリア（プロフィールリンクと登壇一覧） -->
+        <div
+          v-if="openRows.has(rec.name)"
+          :id="panelId(rec.name)"
+          class="bg-paper-2 border-t border-rule-softer pt-2 pb-[22px] px-pad-x"
+        >
+          <!-- スピーカープロフィールページへのリンク -->
+          <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+          <!-- @vize:ignore-start -->
+          <a
+            class="font-mono text-[12px] tracking-[0.06em] text-ink underline hover:no-underline"
+            :href="`/speakers/${encodeURIComponent(rec.name)}`"
+          >
+            {{ t.speaker_profile }}: {{ lang === "en" && rec.nameEn ? rec.nameEn : rec.name }}
+          </a>
+          <!-- @vize:ignore-end -->
+          <!-- 登壇一覧リスト -->
+          <ol class="list-none p-0 m-0 mt-[14px]">
+            <!-- 各登壇情報（開催年・タイトル・共同登壇者） -->
+            <li
+              v-for="(talk, k) in rec.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[30px_1fr] gap-4 items-baseline py-1.5 border-t border-rule-softer"
+              :class='k === 0 ? "border-t-0" : ""'
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
+              <!-- @vize:ignore-start -->
+              <a
+                class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
+                :href="`/${talk.year}`"
+              >
+                {{ talk.year }}
+              </a>
+              <!-- @vize:ignore-end -->
+              <div class="flex flex-col gap-y-[8px]">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
                 <!-- @vize:ignore-start -->
                 <a
-                  class="underline hover:no-underline font-mono text-[12px] text-ink tabular-nums"
-                  :href="`/${talk.year}`"
+                  class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
                 >
-                  {{ talk.year }}
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span class="group-hover:underline">
+                    {{ talk.title || t.tbd }}
+                  </span>
+                  <span class="font-mono text-[10px] text-ink-2 ml-1">
+                    ({{ t.external }})
+                  </span>
                 </a>
                 <!-- @vize:ignore-end -->
-                <div class="flex flex-col gap-y-[8px]">
-                  <!-- トークタイトル（外部リンク） -->
-                  <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-[14px] text-ink pb-[1px] leading-[1.45] no-underline group"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :href="talk.url"
-                  >
-                    <!-- パネルセッションのフォーマットバッジ -->
-                    <span
-                      v-if='talk.format === "panel"'
-                      class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15] mr-2"
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
+                    <template v-if="ci > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
+                      :href="`/speakers/${encodeURIComponent(cn)}`"
                     >
-                      {{ t.session_format_panel }}
-                    </span>
-                    <span class="group-hover:underline">
-                      {{ talk.title || t.tbd }}
-                    </span>
-                    <span class="font-mono text-[10px] text-ink-2 ml-1">
-                      ({{ t.external }})
-                    </span>
-                  </a>
-                  <!-- @vize:ignore-end -->
-                  <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-                  <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                    w/
-                    <span v-for="(cn, ci) in talk.coSpeakers" :key="cn" class="contents">
-                      <template v-if="ci > 0">
-                        ,
-                      </template>
-                      <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                      <!-- @vize:ignore-start -->
-                      <a
-                        class="text-ink border-b border-rule-soft pb-[1px] no-underline hover:border-ink"
-                        :href="`/speakers/${encodeURIComponent(cn)}`"
-                      >
-                        {{ cn }}
-                      </a>
-                      <!-- @vize:ignore-end -->
-                    </span>
+                      {{ cn }}
+                    </a>
+                    <!-- @vize:ignore-end -->
                   </span>
-                </div>
-              </li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </section>
-  </main>
+                </span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </li>
+    </ol>
+  </section>
 </template>

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -35,10 +35,10 @@ function selectYear(year: AcceptedYear) {
         <button
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === "all" ? "true" : "false"'
           :class='selectedYear === "all"
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
-          :data-active='selectedYear === "all" ? "true" : "false"'
           @click="selectAllYears"
         >
           ALL · {{ counts.all }}
@@ -49,10 +49,10 @@ function selectYear(year: AcceptedYear) {
           :key="y"
           class="inline-flex items-center justify-center min-w-[48px] px-[8px] py-[3px] font-mono text-[12px] tracking-[0.02em] border border-rule cursor-pointer transition-colors"
           type="button"
+          :aria-pressed='selectedYear === y ? "true" : "false"'
           :class='selectedYear === y
             ? "bg-ink text-paper border-ink"
             : "text-ink-2 hover:border-ink hover:text-ink"'
-          :data-active='selectedYear === y ? "true" : "false"'
           @click="() => selectYear(y)"
         >
           {{ y }} · {{ counts[y] }}

--- a/src/composables/useVfjsI18n.ts
+++ b/src/composables/useVfjsI18n.ts
@@ -13,11 +13,13 @@ export interface VfjsTranslations {
   filter_search_ph: string;
   view_timeline: string;
   view_index: string;
+  view_mode: string;
   language: string;
   color_scheme: string;
   color_scheme_light: string;
   color_scheme_dark: string;
   color_scheme_system: string;
+  skip_to_content: string;
   empty: string;
   tbd: string;
   external: string;
@@ -28,6 +30,16 @@ export interface VfjsTranslations {
   official_site: string;
   related_talks: string;
   all_speakers: string;
+  directory_heading: (count: number, sortLabel: string) => string;
+  sort_appearances: string;
+  sort_name_asc: string;
+  sort_name_desc: string;
+  sort_latest: string;
+  sort_group: string;
+  filter_result_status: (shown: number, total: number) => string;
+  row_expand: (name: string, count: number) => string;
+  row_collapse: (name: string, count: number) => string;
+  year_speakers_link: (year: string) => string;
   not_found_title: string;
   not_found_description: string;
   year_total_talks: (n: number) => string;
@@ -49,11 +61,13 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_search_ph: "発表タイトル・スピーカー名で検索",
     view_timeline: "タイムライン",
     view_index: "スピーカー",
+    view_mode: "表示切替",
     language: "言語",
     color_scheme: "配色",
     color_scheme_light: "ライト",
     color_scheme_dark: "ダーク",
     color_scheme_system: "システム",
+    skip_to_content: "本文へ",
     empty: "該当するスピーカーが見つかりません。",
     tbd: "タイトル未定",
     external: "外部サイトへ移動",
@@ -64,6 +78,18 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     official_site: "公式サイト",
     related_talks: "発表一覧",
     all_speakers: "発表者一覧",
+    directory_heading: (count: number, sortLabel: string) =>
+      `スピーカー一覧（${count}名・${sortLabel}）`,
+    sort_appearances: "登壇回数の多い順",
+    sort_name_asc: "名前 A→Z",
+    sort_name_desc: "名前 Z→A",
+    sort_latest: "最新登壇年の新しい順",
+    sort_group: "並び替え",
+    filter_result_status: (shown: number, total: number) =>
+      total === 0 ? "該当するスピーカーが見つかりません。" : `${total}件中${shown}件を表示`,
+    row_expand: (name: string, count: number) => `${name}、${count}回登壇、詳細を開く`,
+    row_collapse: (name: string, count: number) => `${name}、${count}回登壇、詳細を閉じる`,
+    year_speakers_link: (year: string) => `${year}年のスピーカー一覧`,
     not_found_title: "ページが見つかりません",
     not_found_description: "指定されたページは存在しないか、移動した可能性があります。",
     year_total_talks: (n: number) => `全 ${n} 発表`,
@@ -83,11 +109,13 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_search_ph: "Search talk titles or speaker names",
     view_timeline: "Timeline",
     view_index: "Speakers",
+    view_mode: "View mode",
     language: "Language",
     color_scheme: "Color scheme",
     color_scheme_light: "Light",
     color_scheme_dark: "Dark",
     color_scheme_system: "System",
+    skip_to_content: "Skip to content",
     empty: "No speakers match the current filters.",
     tbd: "TBD",
     external: "External Site",
@@ -98,6 +126,18 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     official_site: "Official site",
     related_talks: "Talks",
     all_speakers: "Speakers",
+    directory_heading: (count: number, sortLabel: string) => `Speakers (${count} · ${sortLabel})`,
+    sort_appearances: "Most appearances",
+    sort_name_asc: "Name A→Z",
+    sort_name_desc: "Name Z→A",
+    sort_latest: "Latest year",
+    sort_group: "Sort by",
+    filter_result_status: (shown: number, total: number) =>
+      total === 0 ? "No speakers match the current filters." : `Showing ${shown} of ${total}`,
+    row_expand: (name: string, count: number) => `${name}, ${count} appearances, expand details`,
+    row_collapse: (name: string, count: number) =>
+      `${name}, ${count} appearances, collapse details`,
+    year_speakers_link: (year: string) => `${year} speakers`,
     not_found_title: "Page Not Found",
     not_found_description: "The page you requested does not exist or may have moved.",
     year_total_talks: (n: number) => `${n} talks total`,

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import type { AcceptedYear, SpeakerWithYear } from "../../types";
 import { YEARS } from "../../types";
 import AppFooter from "../components/AppFooter.vue";
@@ -15,10 +15,24 @@ const { allSpeakers } = defineProps<{
 
 const { t } = useVfjsI18n();
 
-const view = ref<"chronicle" | "index">("chronicle");
+type ViewMode = "chronicle" | "index";
+
+const TAB_IDS: Record<ViewMode, string> = {
+  chronicle: "tab-chronicle",
+  index: "tab-directory",
+};
+
+const PANEL_IDS: Record<ViewMode, string> = {
+  chronicle: "panel-chronicle",
+  index: "panel-directory",
+};
+
+const view = ref<ViewMode>("chronicle");
+const chronicleTabRef = ref<HTMLButtonElement | null>(null);
+const directoryTabRef = ref<HTMLButtonElement | null>(null);
 
 onMounted(() => {
-  const storedView = localStorage.getItem("vfjs:view") as "chronicle" | "index" | null;
+  const storedView = localStorage.getItem("vfjs:view") as ViewMode | null;
   if (storedView === "chronicle" || storedView === "index") view.value = storedView;
 });
 
@@ -43,12 +57,40 @@ const stats = computed(() => {
   };
 });
 
+function focusTab(mode: ViewMode) {
+  void nextTick(() => {
+    const target = mode === "chronicle" ? chronicleTabRef.value : directoryTabRef.value;
+    target?.focus();
+  });
+}
+
 function showChronicle() {
   view.value = "chronicle";
 }
 
 function showDirectory() {
   view.value = "index";
+}
+
+function onTabKeydown(event: KeyboardEvent, current: ViewMode) {
+  if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+    event.preventDefault();
+    const next: ViewMode = current === "chronicle" ? "index" : "chronicle";
+    view.value = next;
+    focusTab(next);
+    return;
+  }
+  if (event.key === "Home") {
+    event.preventDefault();
+    showChronicle();
+    focusTab("chronicle");
+    return;
+  }
+  if (event.key === "End") {
+    event.preventDefault();
+    showDirectory();
+    focusTab("index");
+  }
 }
 
 function updateQuery(value: string) {
@@ -71,20 +113,25 @@ function updateSelectedYear(value: AcceptedYear | "all") {
     <AppMasthead :stats />
     <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
     <div
-      aria-label="View mode"
       class="flex gap-0 px-pad-x border-b border-rule bg-paper"
       role="tablist"
+      :aria-label="t.view_mode"
     >
       <!-- 年度別クロニクルビュータブ -->
       <button
+        :id="TAB_IDS.chronicle"
+        ref="chronicleTabRef"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :aria-controls="PANEL_IDS.chronicle"
         :aria-selected='view === "chronicle"'
+        :tabindex='view === "chronicle" ? 0 : -1'
         :class='view === "chronicle"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showChronicle"
+        @keydown='(event) => onTabKeydown(event, "chronicle")'
       >
         {{ t.view_timeline }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -93,14 +140,19 @@ function updateSelectedYear(value: AcceptedYear | "all") {
       </button>
       <!-- スピーカー名索引ディレクトリビュータブ -->
       <button
+        :id="TAB_IDS.index"
+        ref="directoryTabRef"
         class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
         role="tab"
         type="button"
+        :aria-controls="PANEL_IDS.index"
         :aria-selected='view === "index"'
+        :tabindex='view === "index" ? 0 : -1'
         :class='view === "index"
           ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
           : "text-ink-3 hover:text-ink"'
         @click="showDirectory"
+        @keydown='(event) => onTabKeydown(event, "index")'
       >
         {{ t.view_index }}
         <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
@@ -108,29 +160,44 @@ function updateSelectedYear(value: AcceptedYear | "all") {
         </span>
       </button>
     </div>
-    <!-- 選択中のビューに応じてコンポーネントを切り替え -->
-    <!-- 年度別クロニクルビュー -->
-    <ChronicleView
-      v-if='view === "chronicle"'
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
-    <!-- スピーカー索引ディレクトリビュー -->
-    <DirectoryView
-      v-else
-      :all-speakers
-      :query
-      :selected-speaker
-      :selected-year
-      @update:query="updateQuery"
-      @update:selected-speaker="updateSelectedSpeaker"
-      @update:selected-year="updateSelectedYear"
-    />
+    <main id="main">
+      <!-- 年度別クロニクルビュー -->
+      <div
+        :id="PANEL_IDS.chronicle"
+        role="tabpanel"
+        :aria-labelledby="TAB_IDS.chronicle"
+        :hidden='view !== "chronicle"'
+      >
+        <ChronicleView
+          v-if='view === "chronicle"'
+          :all-speakers
+          :query
+          :selected-speaker
+          :selected-year
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
+      <!-- スピーカー索引ディレクトリビュー -->
+      <div
+        :id="PANEL_IDS.index"
+        role="tabpanel"
+        :aria-labelledby="TAB_IDS.index"
+        :hidden='view !== "index"'
+      >
+        <DirectoryView
+          v-if='view === "index"'
+          :all-speakers
+          :query
+          :selected-speaker
+          :selected-year
+          @update:query="updateQuery"
+          @update:selected-speaker="updateSelectedSpeaker"
+          @update:selected-year="updateSelectedYear"
+        />
+      </div>
+    </main>
     <AppFooter />
   </div>
 </template>

--- a/src/islands/SpeakerPageIsland.vue
+++ b/src/islands/SpeakerPageIsland.vue
@@ -44,131 +44,134 @@ const record = computed(() => {
   <div>
     <AppHeader />
     <!-- スピーカーページのメインコンテンツ（該当スピーカーが存在する場合） -->
-    <template v-if="found">
-      <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
-      <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
-        <!-- スピーカー名 -->
-        <h1
-          class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
-          :lang='hasJapanese(record.name) ? "ja" : "en"'
-        >
-          <ruby v-if='record.nameRuby && lang === "ja"'>
-            {{ record.name }}
-            <rt>
-              {{ record.nameRuby }}
-            </rt>
-          </ruby>
-          <template v-else>
-            {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
-          </template>
-        </h1>
-        <div class="font-mono text-ink-2">
-          <!-- 総登壇回数 -->
-          <div>
-            {{ t.appearance_count(record.talks.length) }}
-          </div>
-          <!-- 登壇年度のリスト（各年度ページへのリンク） -->
-          <div class="mt-2 text-[12px] text-ink-2">
-            {{ t.years_appeared }}:
-            <span v-for="(year, index) in record.years" :key="year">
-              <template v-if="index > 0">
-                ,
-              </template>
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${year}`">
-                {{ year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-          </div>
-        </div>
-      </header>
-      <!-- 関連トーク一覧セクション -->
-      <section class="px-pad-x py-10">
-        <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
-          {{ t.related_talks }}
-        </h2>
-        <ul class="list-none p-0 m-0">
-          <li
-            v-for="talk in record.talks"
-            :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
-            class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+    <main id="main">
+      <template v-if="found">
+        <!-- スピーカーページのヘッダー（名前・登壇回数・登壇年度） -->
+        <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">
+          <!-- スピーカー名 -->
+          <h1
+            class="font-display text-[clamp(28px,4.5vw,72px)] font-bold leading-[1] mb-4"
+            :lang='hasJapanese(record.name) ? "ja" : "en"'
           >
-            <!-- 開催年リンク（年度別ページへ） -->
-            <span class="font-mono text-[12px] text-center pt-[3px]">
-              <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
-              <!-- @vize:ignore-start -->
-              <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
-                {{ talk.year }}
-              </a>
-              <!-- @vize:ignore-end -->
-            </span>
-            <div class="flex flex-col gap-y-2">
-              <!-- トークタイトル（外部リンク） -->
-              <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
-              <!-- @vize:ignore-start -->
-              <a
-                class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
-                rel="noopener noreferrer"
-                target="_blank"
-                :href="talk.url"
-              >
-                <!-- パネルセッションのフォーマットバッジ -->
-                <span
-                  v-if='talk.format === "panel"'
-                  class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
-                >
-                  {{ t.session_format_panel }}
-                </span>
-                <span>
-                  <span
-                    class="group-hover:underline"
-                    :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
-                  >
-                    {{ talk.title || t.tbd }}
-                  </span>
-                  <span class="text-[10px] ml-1">
-                    ({{ t.external }})
-                  </span>
-                </span>
-              </a>
-              <!-- @vize:ignore-end -->
-              <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
-              <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
-                w/
-                <span
-                  v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
-                  :key="coSpeakerName"
-                  class="contents"
-                >
-                  <template v-if="coSpeakerIndex > 0">
-                    ,
-                  </template>
-                  <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
-                  <!-- @vize:ignore-start -->
-                  <a
-                    class="text-ink underline hover:no-underline"
-                    :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
-                  >
-                    {{ coSpeakerName }}
-                  </a>
-                  <!-- @vize:ignore-end -->
-                </span>
+            <ruby v-if='record.nameRuby && lang === "ja"'>
+              {{ record.name }}
+              <rt>
+                {{ record.nameRuby }}
+              </rt>
+            </ruby>
+            <template v-else>
+              {{ lang === "en" && record.nameEn ? record.nameEn : record.name }}
+            </template>
+          </h1>
+          <div class="font-mono text-ink-2">
+            <!-- 総登壇回数 -->
+            <div>
+              {{ t.appearance_count(record.talks.length) }}
+            </div>
+            <!-- 登壇年度のリスト（各年度ページへのリンク） -->
+            <div class="mt-2 text-[12px] text-ink-2">
+              {{ t.years_appeared }}:
+              <span v-for="(year, index) in record.years" :key="year">
+                <template v-if="index > 0">
+                  ,
+                </template>
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${year}`">
+                  {{ year }}
+                </a>
+                <!-- @vize:ignore-end -->
               </span>
             </div>
-          </li>
-        </ul>
-      </section>
-    </template>
-    <!-- スピーカーが存在しない場合 -->
-    <main v-else class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
-      <h1 class="font-display text-[40px] text-ink m-0">
-        Speaker Not Found
-      </h1>
-      <p>
-        {{ speakerName }}
-      </p>
+          </div>
+        </header>
+        <!-- 関連トーク一覧セクション -->
+        <section class="px-pad-x py-10">
+          <h2 class="font-mono tracking-[0.1em] text-ink-2 mb-4">
+            {{ t.related_talks }}
+          </h2>
+          <ul class="list-none p-0 m-0">
+            <li
+              v-for="talk in record.talks"
+              :key='`${talk.year}-${talk.title ?? talk.url}-${talk.coSpeakers.join("|")}`'
+              class="grid grid-cols-[40px_1fr] gap-x-4 border-t border-rule-softer py-4.5"
+            >
+              <!-- 開催年リンク（年度別ページへ） -->
+              <span class="font-mono text-[12px] text-center pt-[3px]">
+                <!-- @vize:docs dynamic route is generated from the speaker's local year list -->
+                <!-- @vize:ignore-start -->
+                <a class="text-ink underline hover:no-underline" :href="`/${talk.year}`">
+                  {{ talk.year }}
+                </a>
+                <!-- @vize:ignore-end -->
+              </span>
+              <div class="flex flex-col gap-y-2">
+                <!-- トークタイトル（外部リンク） -->
+                <!-- @vize:docs external URL comes from versioned Vue Fes speaker data -->
+                <!-- @vize:ignore-start -->
+                <a
+                  class="text-[16px] text-ink no-underline group flex flex-wrap items-baseline gap-2"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  :href="talk.url"
+                >
+                  <!-- パネルセッションのフォーマットバッジ -->
+                  <span
+                    v-if='talk.format === "panel"'
+                    class="relative top-[-1px] inline-flex items-center self-center align-middle font-mono text-[10px] uppercase tracking-[0.06em] border border-ink text-ink px-[5px] py-[1px] leading-[1.15]"
+                  >
+                    {{ t.session_format_panel }}
+                  </span>
+                  <span>
+                    <span
+                      class="group-hover:underline"
+                      :lang='hasJapanese(talk.title || "") ? "ja" : "en"'
+                    >
+                      {{ talk.title || t.tbd }}
+                    </span>
+                    <span class="text-[10px] ml-1">
+                      ({{ t.external }})
+                    </span>
+                  </span>
+                </a>
+                <!-- @vize:ignore-end -->
+                <!-- 共同登壇者のリスト（各スピーカープロフィールへのリンク） -->
+                <span v-if="talk.coSpeakers.length > 0" class="text-[12px] font-mono text-ink-2">
+                  w/
+                  <span
+                    v-for="(coSpeakerName, coSpeakerIndex) in talk.coSpeakers"
+                    :key="coSpeakerName"
+                    class="contents"
+                  >
+                    <template v-if="coSpeakerIndex > 0">
+                      ,
+                    </template>
+                    <!-- @vize:docs dynamic route uses encodeURIComponent for the local speaker name -->
+                    <!-- @vize:ignore-start -->
+                    <a
+                      class="text-ink underline hover:no-underline"
+                      :href="`/speakers/${encodeURIComponent(coSpeakerName)}`"
+                    >
+                      {{ coSpeakerName }}
+                    </a>
+                    <!-- @vize:ignore-end -->
+                  </span>
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+      </template>
+      <template v-else>
+        <div class="px-pad-x py-20 font-mono text-[14px] text-ink-2">
+          <h1 class="font-display text-[40px] text-ink m-0">
+            Speaker Not Found
+          </h1>
+          <p>
+            {{ speakerName }}
+          </p>
+        </div>
+      </template>
     </main>
     <AppFooter />
   </div>

--- a/src/islands/YearPageIsland.vue
+++ b/src/islands/YearPageIsland.vue
@@ -17,7 +17,7 @@ const { t, lang } = useVfjsI18n();
   <div>
     <AppHeader />
     <!-- 年度ページのメインコンテンツ -->
-    <main>
+    <main id="main">
       <template v-if="found">
         <!-- 年度ページのヘッダー（タイトル・トーク数・公式サイトリンク） -->
         <header class="border-b border-rule pt-[clamp(32px,5vw,72px)] pb-[clamp(24px,4vw,48px)] px-pad-x">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #836 の Major 課題 10 件すべてに対応しました。

| Issue | 対応内容 |
|-------|----------|
| #837 | Chronicle の年を `<h2>` 見出しに変更 |
| #838 | Directory にスピーカー一覧見出し（`aria-labelledby`）を追加 |
| #839 | 表示切替を APG Tabs パターンに（`aria-controls` / `tabpanel` / 矢印キー・Home/End） |
| #840 | 年度フィルタに `aria-pressed` を追加 |
| #841 | Directory ソートに `aria-pressed` と日本語ラベルを追加 |
| #842 | スキップリンク「本文へ」＋各ページの `main#main` |
| #843 | ダークモード `--ink-3` を `#878785` に調整（AA 4.5:1 以上） |
| #844 | `html { scroll-padding-top: 72px }` で sticky header 下のフォーカス隠れを防止 |
| #845 | Directory 行ボタンに短い `aria-label`、`aria-controls`、年度グリッドを `aria-hidden` |
| #846 | 検索・フィルタ結果を `role="status" aria-live="polite"` で通知 |

## 主な変更ファイル

- `src/components/ChronicleView.vue` — 年見出し、ライブリージョン
- `src/components/DirectoryView.vue` — 一覧見出し、ソート状態、行ラベル、ライブリージョン
- `src/components/YearFilterBar.vue` — `aria-pressed`
- `src/islands/HomePageIsland.vue` — APG Tabs、`main#main`
- `src/components/AppHeader.vue` — スキップリンク
- `src/assets/css/main.css` — コントラスト、`scroll-padding-top`、`.skip-link` / `.sr-only`
- `src/composables/useVfjsI18n.ts` — 新規 a11y 文言

## 検証

- `vp run lint`
- `vp run format:check`
- `vp run typecheck`
- `vp test run`（23 tests passed）
- 手動確認: スキップリンク、タブ切替、Directory ソートラベル、年度フィルタ、`h2` 年見出し、ダークモード非選択タブのコントラスト

[a11y_major_issues_walkthrough.mp4](https://cursor.com/agents/bc-bc58842c-7eaa-4528-b546-c442e4e9afbf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa11y_major_issues_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc58842c-7eaa-4528-b546-c442e4e9afbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc58842c-7eaa-4528-b546-c442e4e9afbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

