### PR TITLE
fix(a11y): Minor アクセシビリティ課題を修正 (#836)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -12,7 +12,7 @@
   --ink: #1a1a17;
   --ink-2: #3a3a35;
   --ink-3: #6b6b64;
-  --accent: #007f62;
+  --accent: #00785c;
   --accent-ink: #ffffff;
   --pad-x: clamp(24px, 4vw, 72px);
 }
@@ -54,7 +54,7 @@
   --ink: #1a1a17;
   --ink-2: #3a3a35;
   --ink-3: #6b6b64;
-  --accent: #007f62;
+  --accent: #00785c;
   --accent-ink: #ffffff;
 }
 
@@ -143,6 +143,11 @@ html {
     animation-duration: 0.001ms !important;
     transition-duration: 0.001ms !important;
   }
+}
+
+::placeholder {
+  color: var(--ink-3);
+  opacity: 1;
 }
 
 a:focus-visible,

--- a/src/components/AppFooter.test.ts
+++ b/src/components/AppFooter.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import AppFooter from "./AppFooter.vue";
+
+describe("AppFooter", () => {
+  it("GitHub の外部サイト案内をリンク内に置く", () => {
+    const wrapper = mount(AppFooter);
+    const link = wrapper.get('a[href="https://github.com/yamanoku/vuefes-japan-speakers"]');
+
+    expect(link.attributes("rel")).toBe("noopener noreferrer");
+    expect(link.text()).toContain("GitHub");
+    expect(link.text()).toContain("外部サイトへ移動");
+    expect(wrapper.find("a + span").exists()).toBe(false);
+  });
+});

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -21,14 +21,14 @@ const { t } = useVfjsI18n();
       <a
         class="text-inherit no-underline hover:underline hover:text-ink"
         href="https://github.com/yamanoku/vuefes-japan-speakers"
-        rel="noopener"
+        rel="noopener noreferrer"
         target="_blank"
       >
         GitHub
+        <span class="text-[10px] ml-[4px]">
+          ({{ t.external }})
+        </span>
       </a>
-      <span class="text-[10px] ml-[4px]">
-        ({{ t.external }})
-      </span>
     </div>
   </footer>
 </template>

--- a/src/components/AppMasthead.vue
+++ b/src/components/AppMasthead.vue
@@ -23,7 +23,10 @@ const { t } = useVfjsI18n();
         </h1>
       </div>
       <!-- アーカイブ統計情報（スピーカー数・トーク数・開催年数） -->
-      <aside class="basis-80 grow-1 grid items-center col-span-3 font-mono text-[20px] leading-[1.7] tracking-[0.06em] py-4 border-bs-1 border-be-1 border-rule-soft">
+      <aside
+        class="basis-80 grow-1 grid items-center col-span-3 font-mono text-[20px] leading-[1.7] tracking-[0.06em] py-4 border-bs-1 border-be-1 border-rule-soft"
+        :aria-label="t.stats_label"
+      >
         <!-- 総スピーカー数 -->
         <div>
           <b class="text-ink font-[500] not-italic">

--- a/src/components/ChronicleView.test.ts
+++ b/src/components/ChronicleView.test.ts
@@ -23,6 +23,10 @@ describe("ChronicleView", () => {
     expect(wrapper.find('nav[aria-label="年度"]').exists()).toBe(true);
     expect(wrapper.find('a[href="#year-2018"]').exists()).toBe(true);
 
+    const yearLink = wrapper.get('a[href="/2018"]');
+    expect(yearLink.text()).toBe("2018 のスピーカー");
+    expect(yearLink.attributes("aria-label")).toBeUndefined();
+
     const status = wrapper.find('[role="status"]');
     expect(status.attributes("aria-live")).toBe("polite");
     expect(status.text()).toContain("件の発表を表示");
@@ -40,5 +44,21 @@ describe("ChronicleView", () => {
 
     expect(wrapper.find('[role="status"]').text()).toBe("該当するスピーカーが見つかりません。");
     expect(wrapper.findAll("h2")).toHaveLength(0);
+  });
+
+  it("英語名・ふりがなでも発表を絞り込める", () => {
+    const wrapper = mount(ChronicleView, {
+      props: {
+        allSpeakers: museaSpeakers,
+        query: "Taro Yamada",
+        selectedSpeaker: "all",
+        selectedYear: "all",
+      },
+    });
+
+    expect(wrapper.findAll("h2").map((heading) => heading.text())).toEqual(
+      expect.arrayContaining(["2025全 2 発表"]),
+    );
+    expect(wrapper.text()).toContain("山田 太郎");
   });
 });

--- a/src/components/ChronicleView.vue
+++ b/src/components/ChronicleView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
+import { buildSearchHaystack, matchesSearchQuery, urlSearchToken } from "../utils/searchMatch";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { YEARS } from "../../types";
 import SpeakerFilterBar from "./SpeakerFilterBar.vue";
@@ -46,8 +47,8 @@ const filtered = computed(() => {
     if (selectedYear !== "all" && s.year !== selectedYear) return false;
     if (selectedSpeaker !== "all" && !s.name.includes(selectedSpeaker)) return false;
     if (q) {
-      const hay = (s.title || "") + " " + s.name.join(" ");
-      if (!hay.toLowerCase().includes(q)) return false;
+      const hay = buildSearchHaystack(s.title, s.name, s.nameEn, s.nameRuby, urlSearchToken(s.url));
+      if (!matchesSearchQuery(hay, q)) return false;
     }
     return true;
   });
@@ -137,11 +138,10 @@ function updateSelectedYear(value: AcceptedYear | "all") {
           <!-- @vize:docs dynamic route is generated from the local AcceptedYear list -->
           <!-- @vize:ignore-start -->
           <a
-            class="font-mono text-[24px] tracking-[0.08em] uppercase text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
-            :aria-label="`${year} speakers`"
+            class="font-mono text-[14px] tracking-[0.04em] text-ink-2 hover:text-accent transition-colors border-b border-current pb-0.5 no-underline mt-3.5"
             :href="`/${year}`"
           >
-            →
+            {{ t.year_speakers_link(year) }}
           </a>
           <!-- @vize:ignore-end -->
         </div>

--- a/src/components/DirectoryView.test.ts
+++ b/src/components/DirectoryView.test.ts
@@ -63,4 +63,33 @@ describe("DirectoryView", () => {
 
     expect(wrapper.get('[role="status"]').text()).toContain("該当するスピーカーが見つかりません。");
   });
+
+  it("英語名・ふりがな・URLハンドルでもスピーカーを絞り込める", () => {
+    const wrapper = mount(DirectoryView, {
+      props: { ...defaultProps, query: "Taro Yamada" },
+    });
+    expect(wrapper.text()).toContain("山田 太郎");
+
+    const ruby = mount(DirectoryView, {
+      props: { ...defaultProps, query: "やまだ" },
+    });
+    expect(ruby.text()).toContain("山田 太郎");
+
+    const handle = mount(DirectoryView, {
+      props: {
+        ...defaultProps,
+        allSpeakers: [
+          {
+            year: "2025",
+            name: ["やまのく"],
+            nameEn: ["yamanoku"],
+            title: "アクセシビリティ",
+            url: "https://vuefes.jp/2025/speaker/yamanoku",
+          },
+        ],
+        query: "yamanoku",
+      },
+    });
+    expect(handle.text()).toContain("やまのく");
+  });
 });

--- a/src/components/DirectoryView.vue
+++ b/src/components/DirectoryView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, useId } from "vue";
 import type { SpeakerWithYear, AcceptedYear } from "../../types";
+import { buildSearchHaystack, matchesSearchQuery, urlSearchToken } from "../utils/searchMatch";
 import { compareLexicalJa } from "../utils/stringCollate";
 import { buildSpeakerMap, hasJapanese } from "../utils/speakerMap";
 import type { SpeakerRecord } from "../utils/speakerMap";
@@ -49,9 +50,14 @@ const filtered = computed<SpeakerRecord[]>(() => {
     if (selectedYear !== "all" && !rec.years.includes(selectedYear)) return false;
     if (selectedSpeaker !== "all" && rec.name !== selectedSpeaker) return false;
     if (q) {
-      const titles = rec.talks.map((tk) => tk.title || "").join(" ");
-      const hay = (rec.name + " " + titles).toLowerCase();
-      if (!hay.includes(q)) return false;
+      const hay = buildSearchHaystack(
+        rec.name,
+        rec.nameEn,
+        rec.nameRuby,
+        ...rec.talks.map((tk) => tk.title),
+        ...rec.talks.map((tk) => urlSearchToken(tk.url)),
+      );
+      if (!matchesSearchQuery(hay, q)) return false;
     }
     return true;
   });

--- a/src/components/SpeakerFilterBar.test.ts
+++ b/src/components/SpeakerFilterBar.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mount } from "@vue/test-utils";
+import { museaSpeakerOptions } from "../../musea/sample-data";
+import SpeakerFilterBar from "./SpeakerFilterBar.vue";
+
+describe("SpeakerFilterBar", () => {
+  it("検索欄を search ランドマークにしヒントを関連付ける", () => {
+    const wrapper = mount(SpeakerFilterBar, {
+      props: {
+        query: "",
+        selectedSpeaker: "all",
+        speakerOptions: museaSpeakerOptions,
+      },
+    });
+
+    const search = wrapper.get('form[role="search"]');
+    expect(search.attributes("aria-label")).toBe("キーワードで絞り込み");
+
+    const input = wrapper.get("#speaker-filter-search");
+    const hintId = input.attributes("aria-describedby");
+    expect(hintId).toBeTruthy();
+    expect(wrapper.get(`[id="${hintId}"]`).text()).toContain("英語名");
+  });
+});

--- a/src/components/SpeakerFilterBar.vue
+++ b/src/components/SpeakerFilterBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useId } from "vue";
 import { useVfjsI18n } from "../composables/useVfjsI18n";
 
 const { query, selectedSpeaker, speakerOptions } = defineProps<{
@@ -16,6 +17,7 @@ const { t } = useVfjsI18n();
 
 const searchId = "speaker-filter-search";
 const speakerId = "speaker-filter-speaker";
+const searchHintId = useId();
 
 function updateQuery(event: Event) {
   emit("update:query", (event.target as HTMLInputElement).value);
@@ -28,23 +30,34 @@ function updateSelectedSpeaker(event: Event) {
 
 <template>
   <div class="flex flex-wrap gap-6 px-pad-x py-5 border-b border-rule-soft items-center">
-    <!-- テキスト検索フィールド -->
-    <div class="grow-1 basis-[calc((50% - 100%) * 999)] grid grid-cols-[auto_1fr] gap-3 items-center">
+    <!-- テキスト検索フィールド（検索ランドマーク） -->
+    <form
+      class="grow-1 basis-[calc((50% - 100%) * 999)] grid grid-cols-[auto_1fr] gap-3 items-center"
+      role="search"
+      :aria-label="t.filter_search"
+      @submit.prevent
+    >
       <label
         class="font-mono text-[12px] tracking-[0.1em] text-ink whitespace-nowrap"
         :for="searchId"
       >
         {{ t.filter_search }}
       </label>
-      <input
-        class="bg-transparent border-0 border-b border-rule px-0 py-[8px] font-body text-[15px] text-ink outline-none focus:border-accent w-full"
-        type="search"
-        :id="searchId"
-        :placeholder="t.filter_search_ph"
-        :value="query"
-        @input="updateQuery"
-      />
-    </div>
+      <div class="min-w-0">
+        <input
+          class="bg-transparent border-0 border-b border-rule px-0 py-[8px] font-body text-[15px] text-ink outline-none focus:border-accent w-full"
+          type="search"
+          :id="searchId"
+          :aria-describedby="searchHintId"
+          :placeholder="t.filter_search_ph"
+          :value="query"
+          @input="updateQuery"
+        />
+        <p :id="searchHintId" class="sr-only">
+          {{ t.filter_search_hint }}
+        </p>
+      </div>
+    </form>
     <!-- スピーカー絞り込みフィールド -->
     <div class="grow-1 basis-[calc((50% - 100%) * 999)] grid grid-cols-[auto_1fr] gap-[12px] items-center">
       <label

--- a/src/components/YearFilterBar.test.ts
+++ b/src/components/YearFilterBar.test.ts
@@ -27,4 +27,15 @@ describe("YearFilterBar", () => {
     expect(yearButton?.attributes("aria-pressed")).toBe("true");
     expect(yearButton?.text()).toContain("選択中");
   });
+
+  it("年度フィルタは group のみで region と二重ネストしない", () => {
+    const wrapper = mount(YearFilterBar, {
+      props: { selectedYear: "all", counts },
+    });
+
+    expect(wrapper.find('[role="region"]').exists()).toBe(false);
+    expect(wrapper.find('[role="group"]').attributes("aria-labelledby")).toBe(
+      wrapper.get("span").attributes("id"),
+    );
+  });
 });

--- a/src/components/YearFilterBar.vue
+++ b/src/components/YearFilterBar.vue
@@ -26,13 +26,13 @@ function selectYear(year: AcceptedYear) {
 </script>
 
 <template>
-  <div class="px-pad-x py-3.5 border-b border-rule-soft" role="region" :aria-label="t.filter_year">
+  <div class="px-pad-x py-3.5 border-b border-rule-soft">
     <!-- 年度選択ボタングループ -->
     <div class="flex items-center flex-wrap gap-1.5">
       <span :id="yearFilterLabelId" class="font-mono text-[12px] tracking-[0.1em] text-ink mr-3">
         {{ t.filter_year }}
       </span>
-      <!-- group の名前は可視ラベルを参照する（region の aria-label と重複させない） -->
+      <!-- group の名前は可視ラベルを参照する -->
       <div class="flex gap-1.5 flex-wrap" role="group" :aria-labelledby="yearFilterLabelId">
         <!-- 全年度選択ボタン（スピーカー総数を表示） -->
         <button

--- a/src/composables/useVfjsI18n.ts
+++ b/src/composables/useVfjsI18n.ts
@@ -11,6 +11,7 @@ export interface VfjsTranslations {
   filter_all_speakers: string;
   filter_search: string;
   filter_search_ph: string;
+  filter_search_hint: string;
   view_timeline: string;
   view_index: string;
   view_mode: string;
@@ -34,6 +35,8 @@ export interface VfjsTranslations {
   skip_links: string;
   skip_to_main: string;
   skip_to_footer: string;
+  stats_label: string;
+  year_speakers_link: (year: string) => string;
   year_toc: string;
   sort_label: string;
   sort_appearances: string;
@@ -62,6 +65,7 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_all_speakers: "すべての発表者",
     filter_search: "キーワードで絞り込み",
     filter_search_ph: "発表タイトル・スピーカー名で検索",
+    filter_search_hint: "英語名、ふりがな、公式ページの表記でも検索できます。",
     view_timeline: "タイムライン",
     view_index: "スピーカー",
     view_mode: "表示切替",
@@ -85,6 +89,8 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     skip_links: "スキップリンク",
     skip_to_main: "本文へ",
     skip_to_footer: "フッターへ",
+    stats_label: "開催概要",
+    year_speakers_link: (year) => `${year} のスピーカー`,
     year_toc: "年度",
     sort_label: "並び替え",
     sort_appearances: "登壇回数の多い順",
@@ -112,6 +118,7 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     filter_all_speakers: "All speakers",
     filter_search: "Search",
     filter_search_ph: "Search talk titles or speaker names",
+    filter_search_hint: "English names, readings, and official page spellings are included.",
     view_timeline: "Timeline",
     view_index: "Speakers",
     view_mode: "View mode",
@@ -135,6 +142,8 @@ const translations: Record<"ja" | "en", VfjsTranslations> = {
     skip_links: "Skip links",
     skip_to_main: "Skip to main content",
     skip_to_footer: "Skip to footer",
+    stats_label: "Overview",
+    year_speakers_link: (year) => `${year} speakers`,
     year_toc: "Years",
     sort_label: "Sort",
     sort_appearances: "Most appearances",

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -16,4 +16,13 @@ describe("speaker data accessors", () => {
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => YEARS.includes(speaker.year))).toBe(true);
   });
+
+  it("やまのくの英語名を yamanoku として持つ", () => {
+    const speakers = getAllSpeakersWithYear().filter((speaker) =>
+      speaker.name.includes("やまのく"),
+    );
+
+    expect(speakers.length).toBeGreaterThan(0);
+    expect(speakers.every((speaker) => speaker.nameEn?.includes("yamanoku"))).toBe(true);
+  });
 });

--- a/src/data/speakers-2022.ts
+++ b/src/data/speakers-2022.ts
@@ -90,6 +90,7 @@ export const speakers2022: SpeakerInfo[] = [
   },
   {
     name: ["やまのく"],
+    nameEn: ["yamanoku"],
     title: "Vue.js でアクセシブルなコンポーネントをつくるために",
     url: "https://vuefes.jp/2022/sessions/yamanoku",
   },
@@ -126,7 +127,7 @@ export const speakers2022: SpeakerInfo[] = [
   },
   {
     name: ["miyaoka", "うしろのこ", "takanorip", "やまのく", "kazupon"],
-    nameEn: ["miyaoka", "ushironoko", "takanorip", "やまのく", "kazupon"],
+    nameEn: ["miyaoka", "ushironoko", "takanorip", "yamanoku", "kazupon"],
     title: "なるほどVueコンポーネント",
     url: "https://vuefes.jp/2022/#naruhodo-vue-component",
     format: "panel",

--- a/src/data/speakers-2023.ts
+++ b/src/data/speakers-2023.ts
@@ -83,6 +83,7 @@ export const speakers2023: SpeakerInfo[] = [
   },
   {
     name: ["やまのく"],
+    nameEn: ["yamanoku"],
     title: "画面遷移から考えるNuxtアプリケーションをアクセシブルにする方法",
     url: "https://vuefes.jp/2023/sessions/yamanoku",
   },
@@ -154,7 +155,7 @@ export const speakers2023: SpeakerInfo[] = [
   },
   {
     name: ["takanorip", "miyaoka", "wattanx", "やまのく", "うしろのこ", "kazupon"],
-    nameEn: ["takanorip", "miyaoka", "wattanx", "やまのく", "ushironoko", "kazupon"],
+    nameEn: ["takanorip", "miyaoka", "wattanx", "yamanoku", "ushironoko", "kazupon"],
     title: "なぜVueを選んだのか？",
     url: "https://vuefes.jp/2023/#events-panel",
     format: "panel",

--- a/src/data/speakers-2025.ts
+++ b/src/data/speakers-2025.ts
@@ -38,6 +38,7 @@ export const speakers2025: SpeakerInfo[] = [
   },
   {
     name: ["やまのく"],
+    nameEn: ["yamanoku"],
     title: "生成AI時代のWebアプリケーションアクセシビリティ改善",
     url: "https://vuefes.jp/2025/speaker/yamanoku",
   },

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -109,6 +109,7 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["やまのく"],
+    nameEn: ["yamanoku"],
     title: "Vue SFCから見直す正しいHTMLの守り方",
     url: "https://vuefes.jp/2026/speaker/yamanoku",
   },

--- a/src/islands/HomePageIsland.test.ts
+++ b/src/islands/HomePageIsland.test.ts
@@ -7,6 +7,13 @@ import HomePageIsland from "./HomePageIsland.vue";
 describe("HomePageIsland", () => {
   afterEach(() => {
     localStorage.removeItem("vfjs:view");
+    const url = new URL(window.location.href);
+    url.searchParams.delete("view");
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
   });
 
   it("表示切替タブを APG Tabs として関連付ける", () => {
@@ -32,6 +39,8 @@ describe("HomePageIsland", () => {
     // タブパネルはスキップリンク先の main ランドマーク内に置く
     const main = wrapper.get("main#main");
     expect(main.find('[role="tabpanel"]').exists()).toBe(true);
+    expect(main.find("h1").text()).toContain("Vue Fes Japan Speakers");
+    expect(main.find("aside").attributes("aria-label")).toBe("開催概要");
 
     wrapper.unmount();
   });
@@ -58,5 +67,33 @@ describe("HomePageIsland", () => {
     );
 
     wrapper.unmount();
+  });
+
+  it("Directory 選択を URL に残し、view=directory から復元する", async () => {
+    const wrapper = mount(HomePageIsland, {
+      props: { allSpeakers: museaSpeakers },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    await tabs[1]?.trigger("click");
+    await nextTick();
+
+    expect(new URL(window.location.href).searchParams.get("view")).toBe("directory");
+    expect(localStorage.getItem("vfjs:view")).toBe("index");
+    wrapper.unmount();
+
+    const restored = mount(HomePageIsland, {
+      props: { allSpeakers: museaSpeakers },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const restoredTabs = restored.findAll('[role="tab"]');
+    expect(restoredTabs[1]?.attributes("aria-selected")).toBe("true");
+    restored.unmount();
   });
 });

--- a/src/islands/HomePageIsland.vue
+++ b/src/islands/HomePageIsland.vue
@@ -17,13 +17,38 @@ const { t } = useVfjsI18n();
 
 const view = ref<"chronicle" | "index">("chronicle");
 
+function readViewFromUrl(): "chronicle" | "index" | null {
+  if (typeof window === "undefined") return null;
+  const param = new URLSearchParams(window.location.search).get("view");
+  if (param === "directory" || param === "index") return "index";
+  if (param === "chronicle") return "chronicle";
+  return null;
+}
+
+function writeViewToUrl(value: "chronicle" | "index") {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (value === "index") url.searchParams.set("view", "directory");
+  else url.searchParams.delete("view");
+  const next = `${url.pathname}${url.search}${url.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (current !== next) window.history.replaceState(window.history.state, "", next);
+}
+
 onMounted(() => {
+  const fromUrl = readViewFromUrl();
+  if (fromUrl) {
+    view.value = fromUrl;
+    return;
+  }
   const storedView = localStorage.getItem("vfjs:view") as "chronicle" | "index" | null;
   if (storedView === "chronicle" || storedView === "index") view.value = storedView;
 });
 
 watch(view, (value) => {
-  if (typeof window !== "undefined") localStorage.setItem("vfjs:view", value);
+  if (typeof window === "undefined") return;
+  localStorage.setItem("vfjs:view", value);
+  writeViewToUrl(value);
 });
 
 const selectedYear = ref<AcceptedYear | "all">("all");
@@ -102,59 +127,60 @@ function updateSelectedYear(value: AcceptedYear | "all") {
 <template>
   <div>
     <AppHeader />
-    <!-- タイトル・統計情報 -->
-    <AppMasthead :stats />
-    <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
-    <div
-      class="flex gap-0 px-pad-x border-b border-rule bg-paper"
-      role="tablist"
-      :aria-label="t.view_mode"
-    >
-      <!-- 年度別クロニクルビュータブ -->
-      <button
-        ref="chronicleTabRef"
-        class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
-        role="tab"
-        type="button"
-        :id="tabChronicleId"
-        :aria-controls="panelChronicleId"
-        :aria-selected='view === "chronicle"'
-        :tabindex='view === "chronicle" ? 0 : -1'
-        :class='view === "chronicle"
-          ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
-          : "text-ink-3 hover:text-ink"'
-        @click="showChronicle"
-        @keydown="onTabKeydown"
-      >
-        {{ t.view_timeline }}
-        <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
-          Chronicle
-        </span>
-      </button>
-      <!-- スピーカー名索引ディレクトリビュータブ -->
-      <button
-        ref="directoryTabRef"
-        class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
-        role="tab"
-        type="button"
-        :id="tabDirectoryId"
-        :aria-controls="panelDirectoryId"
-        :aria-selected='view === "index"'
-        :tabindex='view === "index" ? 0 : -1'
-        :class='view === "index"
-          ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
-          : "text-ink-3 hover:text-ink"'
-        @click="showDirectory"
-        @keydown="onTabKeydown"
-      >
-        {{ t.view_index }}
-        <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
-          Directory
-        </span>
-      </button>
-    </div>
-    <!-- 選択中のビューに応じてコンポーネントを切り替え（main ランドマークは island が所有） -->
+    <!-- ページ見出しを含む本文（スキップリンク先） -->
     <main id="main" tabindex="-1">
+      <!-- タイトル・統計情報 -->
+      <AppMasthead :stats />
+      <!-- ビュー切り替えタブバー（Chronicle／Directory） -->
+      <div
+        class="flex gap-0 px-pad-x border-b border-rule bg-paper"
+        role="tablist"
+        :aria-label="t.view_mode"
+      >
+        <!-- 年度別クロニクルビュータブ -->
+        <button
+          ref="chronicleTabRef"
+          class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
+          role="tab"
+          type="button"
+          :id="tabChronicleId"
+          :aria-controls="panelChronicleId"
+          :aria-selected='view === "chronicle"'
+          :tabindex='view === "chronicle" ? 0 : -1'
+          :class='view === "chronicle"
+            ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
+            : "text-ink-3 hover:text-ink"'
+          @click="showChronicle"
+          @keydown="onTabKeydown"
+        >
+          {{ t.view_timeline }}
+          <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
+            Chronicle
+          </span>
+        </button>
+        <!-- スピーカー名索引ディレクトリビュータブ -->
+        <button
+          ref="directoryTabRef"
+          class="px-[22px] py-4 font-body font-[500] text-[14px] tracking-[-0.005em] border-r border-rule-soft cursor-pointer"
+          role="tab"
+          type="button"
+          :id="tabDirectoryId"
+          :aria-controls="panelDirectoryId"
+          :aria-selected='view === "index"'
+          :tabindex='view === "index" ? 0 : -1'
+          :class='view === "index"
+            ? "text-ink [box-shadow:inset_0_-4px_0_var(--accent)]"
+            : "text-ink-3 hover:text-ink"'
+          @click="showDirectory"
+          @keydown="onTabKeydown"
+        >
+          {{ t.view_index }}
+          <span class="font-mono text-[12px] tracking-[0.02em] ml-1" lang="en">
+            Directory
+          </span>
+        </button>
+      </div>
+      <!-- 選択中のビューに応じてコンポーネントを切り替え -->
       <!-- 年度別クロニクルビュー -->
       <div
         v-if='view === "chronicle"'

--- a/src/utils/searchMatch.test.ts
+++ b/src/utils/searchMatch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildSearchHaystack, matchesSearchQuery, urlSearchToken } from "./searchMatch";
+
+describe("searchMatch", () => {
+  it("英語名・ふりがな・URLハンドルを検索対象にする", () => {
+    const haystack = buildSearchHaystack(
+      "やまのく",
+      "yamanoku",
+      urlSearchToken("https://vuefes.jp/2025/speaker/yamanoku"),
+      "生成AI時代のWebアプリケーションアクセシビリティ改善",
+    );
+
+    expect(matchesSearchQuery(haystack, "yamanoku")).toBe(true);
+    expect(matchesSearchQuery(haystack, "やまのく")).toBe(true);
+    expect(matchesSearchQuery(haystack, "アクセシビリティ")).toBe(true);
+  });
+
+  it("開催年だけのパスは検索トークンにしない", () => {
+    expect(urlSearchToken("https://vuefes.jp/2025/")).toBeUndefined();
+  });
+});

--- a/src/utils/searchMatch.ts
+++ b/src/utils/searchMatch.ts
@@ -1,0 +1,31 @@
+function asList(value?: string | string[]): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value];
+}
+
+/** 公式ページ URL の末尾（スピーカーハンドル等）を検索対象に含める。 */
+export function urlSearchToken(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    const last = parsed.pathname.split("/").filter(Boolean).at(-1);
+    if (!last || /^\d{4}$/.test(last)) return undefined;
+    return last;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildSearchHaystack(...values: Array<string | string[] | undefined>): string {
+  return values
+    .flatMap((value) => asList(value))
+    .filter((value) => value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+}
+
+export function matchesSearchQuery(haystack: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return haystack.includes(q);
+}


### PR DESCRIPTION
年ページリンクの可視ラベル、search ランドマーク、統計 aside の名前、
h1 の main 内配置、Directory の URL 同期、検索の表記ゆれ、コントラスト調整などの Minor 課題をまとめて対応する。

close #847
close #848 
close #849
close #850
close #851
close #852
close #853
close #854
close #855 
close #856
close #857 
close #858 