### PR TITLE
feat: Vue Fes Japan 2026 の発表タイトルを公式タイムテーブルに合わせて更新

### DIFF
--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -38,4 +38,12 @@ describe("speaker data accessors", () => {
     expect(panel?.title).toBe("JavaScriptエコシステムの境界線を問い直す");
     expect(panel?.name).toEqual(["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir"]);
   });
+
+  it("2026は公式スピーカーページの登壇者を含む", () => {
+    const speakers = getSpeakersByYear("2026");
+    const urls = speakers.map((speaker) => speaker.url);
+
+    expect(speakers.some((speaker) => speaker.name.includes("re-taro"))).toBe(true);
+    expect(urls).toContain("https://vuefes.jp/2026/speaker/re-taro");
+  });
 });

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -25,4 +25,16 @@ describe("speaker data accessors", () => {
     expect(speakers.length).toBeGreaterThan(0);
     expect(speakers.every((speaker) => speaker.nameEn?.includes("yamanoku"))).toBe(true);
   });
+
+  it("2026の更新された発表タイトルを持つ", () => {
+    const speakers = getSpeakersByYear("2026");
+    const byName = (name: string) => speakers.find((speaker) => speaker.name.length === 1 && speaker.name[0] === name);
+    const panel = speakers.find((speaker) => speaker.format === "panel");
+
+    expect(byName("Eduardo San Martin Morote")?.title).toBe("Type-Safe URLs");
+    expect(byName("Charles Wang")?.title).toBe("Vite Task’s Cache Magic");
+    expect(byName("中野 美咲")?.title).toBe("ブランドのためのWebGLアニメーション（仮）");
+    expect(panel?.title).toBe("JavaScriptエコシステムの境界線を問い直す");
+    expect(panel?.name).toEqual(["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir"]);
+  });
 });

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -36,14 +36,29 @@ describe("speaker data accessors", () => {
     expect(byName("Charles Wang")?.title).toBe("Vite Task’s Cache Magic");
     expect(byName("中野 美咲")?.title).toBe("ブランドのためのWebGLアニメーション（仮）");
     expect(panel?.title).toBe("JavaScriptエコシステムの境界線を問い直す");
-    expect(panel?.name).toEqual(["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir"]);
+    expect(panel?.name).toEqual([
+      "Evan You",
+      "古川 陽介",
+      "Alistair Smith",
+      "Leo Kettmeir",
+      "re-taro",
+    ]);
   });
 
-  it("2026は公式スピーカーページの登壇者を含む", () => {
+  it("2026のパネルのみ登壇者は個別エントリを持たない", () => {
     const speakers = getSpeakersByYear("2026");
-    const urls = speakers.map((speaker) => speaker.url);
+    const panelOnly = ["古川 陽介", "Alistair Smith", "Leo Kettmeir", "re-taro"];
 
-    expect(speakers.some((speaker) => speaker.name.includes("re-taro"))).toBe(true);
-    expect(urls).toContain("https://vuefes.jp/2026/speaker/re-taro");
+    for (const name of panelOnly) {
+      const individual = speakers.find(
+        (speaker) => speaker.name.length === 1 && speaker.name[0] === name,
+      );
+      const inPanel = speakers.some(
+        (speaker) => speaker.format === "panel" && speaker.name.includes(name),
+      );
+
+      expect(individual).toBeUndefined();
+      expect(inPanel).toBe(true);
+    }
   });
 });

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -28,7 +28,8 @@ describe("speaker data accessors", () => {
 
   it("2026の更新された発表タイトルを持つ", () => {
     const speakers = getSpeakersByYear("2026");
-    const byName = (name: string) => speakers.find((speaker) => speaker.name.length === 1 && speaker.name[0] === name);
+    const byName = (name: string) =>
+      speakers.find((speaker) => speaker.name.length === 1 && speaker.name[0] === name);
     const panel = speakers.find((speaker) => speaker.format === "panel");
 
     expect(byName("Eduardo San Martin Morote")?.title).toBe("Type-Safe URLs");

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -51,6 +51,10 @@ export const speakers2026: SpeakerInfo[] = [
     url: "https://vuefes.jp/2026/speaker/yosuke-furukawa",
   },
   {
+    name: ["re-taro"],
+    url: "https://vuefes.jp/2026/speaker/re-taro",
+  },
+  {
     name: ["Naoki Haba"],
     title: "Vite+への貢献と、Team Memberになって見えてきた風景",
     url: "https://vuefes.jp/2026/speaker/naokihaba",

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -8,6 +8,7 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["Eduardo San Martin Morote"],
+    title: "Type-Safe URLs",
     url: "https://vuefes.jp/2026/speaker/posva",
   },
   {
@@ -16,7 +17,7 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["Charles Wang"],
-    title: "Vite-plus (仮)",
+    title: "Vite Task’s Cache Magic",
     url: "https://vuefes.jp/2026/speaker/wan9chi",
   },
   {
@@ -26,6 +27,7 @@ export const speakers2026: SpeakerInfo[] = [
   },
   {
     name: ["中野 美咲"],
+    title: "ブランドのためのWebGLアニメーション（仮）",
     url: "https://vuefes.jp/2026/speaker/mnmxmx",
   },
   {
@@ -172,5 +174,11 @@ export const speakers2026: SpeakerInfo[] = [
     name: ["キナ"],
     title: "便利で危険なDeep Reactivityとの付き合い方",
     url: "https://vuefes.jp/2026/speaker/CrafterKina",
+  },
+  {
+    name: ["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir"],
+    title: "JavaScriptエコシステムの境界線を問い直す",
+    url: "https://vuefes.jp/2026/event?session=panel-discussion#panel-discussion",
+    format: "panel",
   },
 ];

--- a/src/data/speakers-2026.ts
+++ b/src/data/speakers-2026.ts
@@ -31,28 +31,12 @@ export const speakers2026: SpeakerInfo[] = [
     url: "https://vuefes.jp/2026/speaker/mnmxmx",
   },
   {
-    name: ["Leo Kettmeir"],
-    url: "https://vuefes.jp/2026/speaker/crowlKats",
-  },
-  {
-    name: ["Alistair Smith"],
-    url: "https://vuefes.jp/2026/speaker/alii",
-  },
-  {
     name: ["Kongkeit Khunpanitchot (aka saltyaom)"],
     url: "https://vuefes.jp/2026/speaker/SaltyAom",
   },
   {
     name: ["Yusuke Wada"],
     url: "https://vuefes.jp/2026/speaker/yusukebe",
-  },
-  {
-    name: ["古川 陽介"],
-    url: "https://vuefes.jp/2026/speaker/yosuke-furukawa",
-  },
-  {
-    name: ["re-taro"],
-    url: "https://vuefes.jp/2026/speaker/re-taro",
   },
   {
     name: ["Naoki Haba"],
@@ -180,7 +164,7 @@ export const speakers2026: SpeakerInfo[] = [
     url: "https://vuefes.jp/2026/speaker/CrafterKina",
   },
   {
-    name: ["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir"],
+    name: ["Evan You", "古川 陽介", "Alistair Smith", "Leo Kettmeir", "re-taro"],
     title: "JavaScriptエコシステムの境界線を問い直す",
     url: "https://vuefes.jp/2026/event?session=panel-discussion#panel-discussion",
     format: "panel",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

[Vue Fes Japan 2026 タイムテーブル](https://vuefes.jp/2026/timetable) と [スピーカー一覧](https://vuefes.jp/2026/speaker) を照合し、公開済みの発表タイトルを更新し、未登録のスピーカーを追加しました。

## 変更内容

### タイトル更新

- **Eduardo San Martin Morote**: タイトル未設定 → `Type-Safe URLs`
- **Charles Wang**: `Vite-plus (仮)` → `Vite Task’s Cache Magic`
- **中野 美咲**: タイトル未設定 → `ブランドのためのWebGLアニメーション（仮）`
- **パネルディスカッション** を追加: `JavaScriptエコシステムの境界線を問い直す`

### スピーカー / パネル

- **古川 陽介 / Alistair Smith / Leo Kettmeir / re-taro** はパネルのみの登壇として扱い、個別エントリは削除
- **Evan You** はキーノートを個別に残し、パネルにも含める
- **re-taro**（ファシリテーター）はパネルの共同登壇者として追加

既存タイトル（キーノート、LT、その他セッション）は公式ページと一致していたため変更していません。Pooya Parsa / Kongkeit Khunpanitchot / Yusuke Wada はタイムテーブル未掲載のためタイトルは据え置きです。

## 確認

- `vp run lint` / `vp run format:check` / `vp run typecheck`
- `vp test run`（15 files / 44 tests）
- `/2026` のパネル行、4名の詳細（パネルのみ）、Evan You の 2026 キーノート＋パネルを確認

[2026 year page panel-only row](https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyear_2026_panel_only_row.webp)
[re-taro speaker page panel only](https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeaker_retaro_panel_only.webp)
[Furukawa speaker page panel only](https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeaker_furukawa_panel_only.webp)
[Evan You 2026 keynote and panel](https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeaker_evan_you_keynote_and_panel.webp)
[verify_2026_panel_only_speakers-2.mp4](https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_2026_panel_only_speakers-2.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef05815f-49ff-4ac7-a8e4-3b4977b2792c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

